### PR TITLE
fix(mac): JXA get-windows stdout + doctor Anthropic error handling Fixes #1

### DIFF
--- a/scripts/mac/get-windows.jxa
+++ b/scripts/mac/get-windows.jxa
@@ -11,6 +11,9 @@
  * - bounds: {x, y, width, height} window position and size
  * - isMinimized: Boolean indicating if window is minimized
  * 
+ * Output: In JXA, console.log() goes to stderr. We use the script result (last
+ * expression) so stdout receives the JSON for Node.js execFile.
+ * 
  * Usage: osascript -l JavaScript get-windows.jxa
  */
 
@@ -39,6 +42,7 @@ function safeElementProp(element, propName, defaultValue) {
     }
 }
 
+var output;
 try {
     // Get System Events application
     var SystemEvents = Application('System Events');
@@ -90,9 +94,9 @@ try {
                         // Property not available, assume not minimized
                     }
                     
-                    // macOS doesn't have window handles like Windows,
-                    // but we can use a combination of processId and index
+                    // macOS doesn't have window handles like Windows; use processId as handle equivalent
                     results.push({
+                        handle: processId,
                         title: title,
                         processName: processName,
                         processId: processId,
@@ -108,11 +112,9 @@ try {
         }
     }
     
-    // Output JSON to stdout
-    console.log(JSON.stringify(results, null, 0));
-    
+    output = JSON.stringify(results, null, 0);
 } catch (error) {
-    // Output error as JSON
-    console.log(JSON.stringify({ error: error.toString() }));
+    output = JSON.stringify({ error: error.toString() });
     $.exit(1);
 }
+output;

--- a/src/accessibility.ts
+++ b/src/accessibility.ts
@@ -501,15 +501,17 @@ export class AccessibilityBridge {
           return;
         }
 
+        // On macOS, JXA's console.log() writes to stderr, not stdout. Use stdout first, then stderr fallback.
+        const raw = (typeof stdout === 'string' && stdout.trim()) || (typeof stderr === 'string' && stderr.trim()) || '';
         try {
-          const result = JSON.parse(stdout.trim());
+          const result = JSON.parse(raw);
           if (result.error) {
             reject(new Error(result.error));
           } else {
             resolve(result);
           }
         } catch (parseErr) {
-          console.error(`Failed to parse ${resolvedScript} output:`, stdout.substring(0, 200));
+          console.error(`Failed to parse ${resolvedScript} output:`, raw.substring(0, 200));
           reject(parseErr);
         }
       });

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -242,7 +242,10 @@ async function testModel(
 
       const data = await response.json() as any;
       if (data.error) {
-        return { ok: false, error: data.error.message || JSON.stringify(data.error) };
+        const msg = typeof data.error === 'object' && data.error !== null
+          ? (data.error.message || JSON.stringify(data.error))
+          : String(data.error);
+        return { ok: false, error: msg };
       }
       const text = data.choices?.[0]?.message?.content || '';
       if (!text) return { ok: false, error: 'Empty response' };
@@ -266,8 +269,21 @@ async function testModel(
       });
 
       const data = await response.json() as any;
+      if (data.type === 'error' && data.error) {
+        const err = data.error;
+        const msg = typeof err === 'object' && err !== null
+          ? (err.message || JSON.stringify(err))
+          : String(err);
+        const hint = (err.type === 'not_found_error' || err.type === 'invalid_request_error')
+          ? ' — check model id (e.g. claude-haiku-3-5-20241022)'
+          : '';
+        return { ok: false, error: msg + hint };
+      }
       if (data.error) {
-        return { ok: false, error: data.error.message || JSON.stringify(data.error) };
+        const msg = typeof data.error === 'object' && data.error !== null
+          ? (data.error.message || JSON.stringify(data.error))
+          : String(data.error);
+        return { ok: false, error: msg };
       }
 
       return { ok: true, latencyMs: Math.round(performance.now() - start) };


### PR DESCRIPTION
Fixes #1
## Problem
- On macOS, doctor failed with: `Failed to parse get-windows.jxa output: SyntaxError: Unexpected end of JSON input`.
- Text model failure showed an opaque message (e.g. `model: claude-haiku-4-20250414`).

## Cause
- In JXA (osascript -l JavaScript), `console.log()` writes to **stderr**. Node's `execFile()` only captured stdout, so the bridge received empty input and `JSON.parse` threw.
- Doctor did not explicitly handle Anthropic's error shape or suggest checking the model id.

## Changes
1. **accessibility.ts**: Use stderr as fallback when stdout is empty so JXA output is parsed regardless of stream.
2. **get-windows.jxa**: Output JSON via script result (last expression) so it goes to stdout; add `handle` for WindowInfo compatibility.
3. **doctor.ts**: Parse Anthropic `type: "error"` and `error.message`; for not_found/invalid_request append a hint to check the model id.

## Testing
- `node dist/index.js doctor` on macOS: accessibility bridge reports "N windows detected" with no parse error.
- get-windows.jxa run directly: JSON on stdout, valid structure.