### PR TITLE
docs: add v0.5.6 compatibility audit and sync SKILL metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ clawdcursor start --provider openai
 
 ---
 
+## Compatibility (v0.5.6 Audit)
+
+| OS | Status | Notes |
+|----|--------|-------|
+| Windows 10/11 | ✅ Full support | Native desktop automation via PowerShell + UI Automation scripts. |
+| macOS 13+ | ✅ Full support | Native desktop automation via JXA/System Events scripts. |
+| Linux | ⚠️ Partial support | Browser/CDP flows work. Native desktop automation requires X11 native libs (for `@nut-tree-fork/nut-js`) and may still vary by distro/desktop environment. |
+
+**Linux prerequisites for native automation** (Debian/Ubuntu example):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y libxtst6 libx11-xcb1 libxcomposite1 libxdamage1 libxfixes3 libxi6 libxrandr2 libxtst-dev
+```
+
+If these libraries are missing, `clawdcursor doctor` can fail on startup with errors like `libXtst.so.6: cannot open shared object file`.
+
+---
+
 ## How It Works
 
 ### The 5-Layer Pipeline

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdcursor
-version: 0.5.5
+version: 0.5.6
 description: >
   AI desktop agent — control any app on Windows/macOS from your OpenClaw agent.
   Send natural language tasks to the Clawd Cursor API and it handles everything:
@@ -122,7 +122,7 @@ Before your first task, verify Clawd Cursor is running:
 curl.exe -s http://127.0.0.1:3847/health
 ```
 
-Expected: `{"status":"ok","version":"0.5.5"}`
+Expected: `{"status":"ok","version":"0.5.6"}`
 
 If connection refused — **start it yourself** (don't ask the user):
 ```powershell


### PR DESCRIPTION
### Motivation
- Provide a concise compatibility audit for the new `0.5.6` release so users know OS support and any native prerequisites. 
- Surface the Linux-native dependency failure observed during runtime (`libXtst.so.6`) and give actionable install steps. 
- Keep SKILL metadata and README examples consistent with the packaged release version to avoid confusion when installing as an OpenClaw skill.

### Description
- Added a new **Compatibility (v0.5.6 Audit)** section to `README.md` containing an OS support matrix and a Debian/Ubuntu install snippet for X11/native libs required by `@nut-tree-fork/nut-js`.
- Documented the observed runtime error mode (`libXtst.so.6: cannot open shared object file`) and linked it to missing Linux packages. 
- Updated `SKILL.md` `version` field to `0.5.6` and synchronized the health-check example in the docs to `{"status":"ok","version":"0.5.6"}` for consistency.

### Testing
- `npm run build` completed successfully (TypeScript compile + `postbuild` message). 
- `npm test` (Vitest smoke tests) passed: 1 test file, 5 tests all green. 
- `npm run lint` failed with 557 errors, mainly due to Node global identifiers flagged as undefined and many `@typescript-eslint/no-explicit-any`/unused-variable issues. 
- Running `node dist/index.js doctor --no-save` failed in this environment with `ERR_DLOPEN_FAILED` because `libXtst.so.6` (Linux X11 native lib) is missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a153ab348327b7993f6dcb2ec9cc)