### PR TITLE
Docs: add OpenClaw integration recommendations and clarify Clawd Cursor routing/usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Clawd Cursor ships as an [OpenClaw](https://openclaw.ai) skill. Install it and a
 
 The [`SKILL.md`](SKILL.md) teaches agents **when and how** to use Clawd Cursor: REST API for full desktop control, CDP direct for fast browser reads. Agents learn to be independent — no more asking you to screenshot or copy-paste things they can do themselves.
 
+For orchestration best practices (how to avoid overlap and keep OpenClaw + Clawd Cursor efficient), see [docs/OPENCLAW-INTEGRATION-RECOMMENDATIONS.md](docs/OPENCLAW-INTEGRATION-RECOMMENDATIONS.md).
+
 ```bash
 # Install as OpenClaw skill
 openclaw skills install clawd-cursor

--- a/SKILL.md
+++ b/SKILL.md
@@ -60,7 +60,14 @@ No task is impossible. If it's on the screen, it's within reach.
 
 You have a desktop UI agent available. Use it when the user asks you to interact with their desktop, or when no other tool can accomplish the task.
 
-### Use Clawd Cursor for:
+### Tool vs Skill (OpenClaw terminology)
+- **Tool** = direct capability (API call, filesystem, shell, web fetch, browser command).
+- **Skill** = packaged workflow/domain logic that may call one or more tools.
+- **This skill (Clawd Cursor)** = GUI execution skill. Use it after OpenClaw tools/skills that can complete the same work without GUI.
+
+### Use Clawd Cursor for (examples, not limits):
+Clawd Cursor can perform **any action that is visible and interactable in the GUI** (subject to safety policy).
+
 - **User-requested desktop tasks** — "open Gmail and send an email", "check my calendar"
 - **Read a webpage** — when web_fetch or browser tools aren't available
 - **Interact with desktop apps** — click buttons, fill forms, read results
@@ -83,6 +90,29 @@ You have a desktop UI agent available. Use it when the user asks you to interact
 - You can already read/write the file directly
 - The browser tool or web_fetch can handle it
 
+## OpenClaw + Clawd Cursor Routing Contract (Avoid Overlap)
+
+Clawd Cursor should be treated as **OpenClaw's GUI execution layer**, not a competing planner.
+
+### Route tasks in this order:
+1. **OpenClaw native tools first** (filesystem, API, shell, provider-native skills)
+2. **Browser-native automation next** (Playwright/CDP direct) for browser-only reads/clicks
+3. **Clawd Cursor API task (`POST /task`)** only when desktop/UI-level interaction is required
+
+### Practical rule
+- If OpenClaw already has a reliable skill/tool for the domain, use it.
+- Use Clawd Cursor to bridge gaps where no API/tool exists or when the user explicitly asks for GUI interaction.
+
+This keeps behavior predictable, lowers latency/cost, and avoids duplicated logic between the main OpenClaw agent and this skill.
+
+### Universal task pattern
+For broad "get it done" requests, split into three phases:
+1. **Plan in OpenClaw**: break work into API/CLI/browser/GUI subtasks.
+2. **Execute cheap paths first**: API + CLI + browser direct.
+3. **Escalate only residual UI steps** to Clawd Cursor.
+
+Think: **"OpenClaw decides, Clawd Cursor acts on GUI when needed."**
+
 ### Direct Browser Access (Fast Path)
 For quick page reads without a full task, connect to Chrome via Playwright CDP:
 ```js
@@ -97,11 +127,11 @@ Use this when you just need page content — faster than sending a task.
 | Scenario | Use | Why |
 |----------|-----|-----|
 | Read page content/text | CDP Direct | Instant, free |
-| Fill a web form | REST API | Clawd handles multi-step planning |
+| Fill a web form | API task (`POST /task`) | Clawd handles multi-step planning |
 | Check if a page loaded | CDP Direct | Just read the title/URL |
-| Click through a complex UI flow | REST API | Clawd handles planning |
+| Click through a complex UI flow | API task (`POST /task`) | Clawd handles planning |
 | Get a list of elements on page | CDP Direct | Fast DOM query |
-| Interact with a desktop app | REST API | CDP is browser-only |
+| Interact with a desktop app | API task (`POST /task`) | CDP is browser-only |
 
 ---
 

--- a/docs/OPENCLAW-INTEGRATION-RECOMMENDATIONS.md
+++ b/docs/OPENCLAW-INTEGRATION-RECOMMENDATIONS.md
@@ -1,0 +1,78 @@
+# OpenClaw + Clawd Cursor Efficiency Recommendations
+
+This guide defines how to make OpenClaw and Clawd Cursor work together without duplicate effort.
+
+## 1) Troubleshooting model: identify the bottleneck first
+
+When automation feels slow or flaky, classify failures into one of four buckets:
+
+1. **Routing problem** - GUI used for work that had a direct API/CLI path.
+2. **Planning problem** - task prompt too broad, causing unnecessary UI exploration.
+3. **Execution problem** - target app/window not focused, selector ambiguity, confirmation gate waits.
+4. **Provider problem** - slow/expensive model used when a cheap text path would suffice.
+
+## 2) Default routing policy (recommended)
+
+Use this precedence for every request:
+
+1. **OpenClaw native capability** (API, local files, shell, existing domain skill)
+2. **Browser direct path** (Playwright/CDP)
+3. **Clawd Cursor GUI path** (REST `/task`) only for residual UI steps
+
+This prevents Clawd Cursor from re-solving work OpenClaw already solves well.
+
+## 3) Universal task decomposition pattern
+
+For broad user requests, run a 3-phase pattern:
+
+- **Phase A - Plan in OpenClaw**
+  - Decompose into API/CLI/browser/GUI subtasks.
+  - Mark each subtask with the cheapest valid execution path.
+- **Phase B - Execute low-cost subtasks first**
+  - API + CLI + browser direct.
+- **Phase C - Escalate only unresolved UI operations**
+  - Send the exact residual actions to Clawd Cursor.
+
+## 4) Prompting recommendations for better GUI reliability
+
+When you do call Clawd Cursor:
+
+- Include app name + objective + expected final state.
+- Avoid vague instructions like "handle this".
+- Prefer one atomic GUI objective per request.
+- Never include credentials in task text.
+
+Example:
+
+- Weak: `Do the payroll thing in the browser`
+- Better: `In the open Chrome tab for ACME Payroll, submit timesheet for Jane Doe for week ending 2026-02-21 and confirm status shows Submitted.`
+
+## 5) Performance recommendations
+
+- Keep Layer 1/2 as default path where possible.
+- Reserve vision-heavy Layer 3 for ambiguous/visual-only states.
+- Reuse active browser/CDP session instead of reopening tabs.
+- Abort and resend with tighter instructions when task status stalls.
+
+## 6) Governance recommendation (no skill overlap)
+
+Define ownership explicitly:
+
+- **OpenClaw owns orchestration** (task breakdown, tool choice, policy)
+- **Clawd Cursor owns GUI execution** (desktop/browser interaction when required)
+
+A simple rule of thumb:
+
+> If OpenClaw can complete the subtask confidently without GUI, do not call Clawd Cursor.
+
+## 7) Minimal metrics to track efficiency
+
+Track these to confirm improvement:
+
+- % of subtasks completed without GUI escalation
+- Median end-to-end task time
+- Mean retries per GUI task
+- Vision-token usage per task
+- Safety confirmation wait time
+
+Improvement target: more tasks completed through OpenClaw native + browser direct, fewer full GUI escalations.


### PR DESCRIPTION
### Motivation
- Provide clear guidance for when OpenClaw should use native tools vs when to escalate to the Clawd Cursor GUI skill to avoid duplicated effort and improve reliability.
- Clarify terminology (Tool vs Skill) and update examples to use the recommended `POST /task` API pattern and Playwright/CDP direct paths.
- Surface orchestration best practices so integrators can reduce latency, cost, and flaky GUI automation by routing tasks in a predictable order.

### Description
- Added a new guidance document `docs/OPENCLAW-INTEGRATION-RECOMMENDATIONS.md` that defines routing policy, task decomposition, prompting and performance recommendations, and minimal metrics to track.
- Expanded `SKILL.md` with a "Tool vs Skill" section, a clear OpenClaw + Clawd Cursor routing contract, a universal task decomposition pattern, and replaced generic "REST API" phrasing with explicit `API task (POST /task)` usage in examples.
- Updated `README.md` and `SKILL.md` to link to the new recommendations doc and adjusted a few examples and table entries for consistency with the routing guidance.

### Testing
- No automated tests were added or modified for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a305ef32b4832789f4aee3137e541e)