### PR TITLE
Fix smoke test default provider expectation

### DIFF
--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -23,7 +23,7 @@ describe('config defaults', () => {
   it('keeps expected defaults', () => {
     expect(DEFAULT_CONFIG.server.port).toBe(3847);
     expect(DEFAULT_CONFIG.server.host).toBe('127.0.0.1');
-    expect(DEFAULT_CONFIG.ai.provider).toBe('anthropic');
+    expect(DEFAULT_CONFIG.ai.provider).toBe('auto');
     expect(DEFAULT_CONFIG.safety.defaultTier).toBe(SafetyTier.Preview);
   });
 });


### PR DESCRIPTION
### Motivation
- A smoke test was asserting `DEFAULT_CONFIG.ai.provider` is `'anthropic'` while the codebase default in `src/types.ts` is `'auto'`, causing a test failure and misrepresenting the project’s provider-universal default.

### Description
- Updated the assertion in `tests/smoke.test.ts` to expect `DEFAULT_CONFIG.ai.provider` to be `'auto'` instead of `'anthropic'` so the test matches the actual default configuration.

### Testing
- Ran `npm test -- --run` and confirmed all tests passed (5/5).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a310e5cd648327a1b85a56e85780f9)