### PR TITLE
Add keyboard shortcut registry with fuzzy/context-aware matching and router telemetry

### DIFF
--- a/AI-SHORTCUTS.md
+++ b/AI-SHORTCUTS.md
@@ -1,0 +1,49 @@
+# AI Keyboard Shortcuts Reference
+
+This project includes a shortcut registry (`src/shortcuts.ts`) that maps natural language intents to keyboard combos.
+
+## Example intents
+
+- `scroll down` → `PageDown`
+- `go to top` → `Control+Home` (`Super+Up` on macOS)
+- `new tab` → `Control+t` (`Super+t` on macOS)
+- `reddit upvote` → `a`
+- `refresh` / `refesh` → `F5` (`Super+r` on macOS)
+
+## Smart behavior
+
+- **Fuzzy matching**: tolerates small typos like `newtab` and `refesh`.
+- **Context-aware social shortcuts**: one-key social shortcuts (Reddit/X) only trigger when task text or active-window context indicates the right site/app.
+- **Platform-aware mapping**: each shortcut resolves to OS-specific combos where needed.
+
+## Categories
+
+- Navigation
+- Browser
+- Editing
+- Social media
+- Window management
+- File operations
+- View
+- Quick actions
+
+## How routing works
+
+`ActionRouter` checks shortcuts early:
+
+1. Build context hint from active window title/process name.
+2. `findShortcut(task, platform, { contextHint })`
+3. `desktop.keyPress(combo)` if matched.
+4. Fall back to existing route handlers or LLM path.
+
+## Telemetry counters
+
+`ActionRouter` now tracks:
+
+- `totalRequests`
+- `shortcutHits`
+- `shortcutFuzzyHits`
+- `nonShortcutHandled`
+- `llmFallbacks`
+
+Use `router.getTelemetry()` and `router.resetTelemetry()` to inspect/clear counters.

--- a/shortcut-demo.md
+++ b/shortcut-demo.md
@@ -1,0 +1,30 @@
+# Shortcut Demo Scenarios
+
+## 1) Browser navigation
+
+- Input: `new tab`
+- Routed combo: `Control+t`
+- Behavior: opens a tab without searching UI elements.
+
+## 2) Typo tolerance (fuzzy)
+
+- Input: `refesh`
+- Routed combo: `F5`
+- Behavior: still resolves to refresh (minor typo accepted).
+
+## 3) Context-aware social shortcuts
+
+- Input: `upvote`
+- Routed combo: none unless context indicates Reddit.
+- Behavior: prevents accidental `a` key presses in unrelated apps.
+
+## 4) Social shortcut with context
+
+- Input: `upvote` + active window hint `reddit.com`
+- Routed combo: `a`
+- Behavior: safe and fast Reddit interaction.
+
+## 5) Telemetry check
+
+- Call `router.getTelemetry()` after tasks.
+- Inspect `shortcutHits` vs `llmFallbacks` to quantify keyboard-first performance impact.

--- a/src/action-router.ts
+++ b/src/action-router.ts
@@ -12,6 +12,7 @@ import { promisify } from 'util';
 import { AccessibilityBridge } from './accessibility';
 import { NativeDesktop } from './native-desktop';
 import { normalizeKey } from './keys';
+import { findShortcut } from './shortcuts';
 import type { WindowInfo } from './accessibility';
 
 const execFileAsync = promisify(execFile);
@@ -22,6 +23,15 @@ export interface RouteResult {
   handled: boolean;
   description: string;
   error?: string;
+}
+
+
+export interface RouterTelemetry {
+  totalRequests: number;
+  shortcutHits: number;
+  shortcutFuzzyHits: number;
+  nonShortcutHandled: number;
+  llmFallbacks: number;
 }
 
 /**
@@ -78,16 +88,38 @@ const READY_SETTLE_MS = 500;      // extra ms after window appears (let UI rende
 export class ActionRouter {
   private a11y: AccessibilityBridge;
   private desktop: NativeDesktop;
+  private telemetry: RouterTelemetry = {
+    totalRequests: 0,
+    shortcutHits: 0,
+    shortcutFuzzyHits: 0,
+    nonShortcutHandled: 0,
+    llmFallbacks: 0,
+  };
 
   constructor(a11y: AccessibilityBridge, desktop: NativeDesktop) {
     this.a11y = a11y;
     this.desktop = desktop;
   }
 
+  getTelemetry(): RouterTelemetry {
+    return { ...this.telemetry };
+  }
+
+  resetTelemetry(): void {
+    this.telemetry = {
+      totalRequests: 0,
+      shortcutHits: 0,
+      shortcutFuzzyHits: 0,
+      nonShortcutHandled: 0,
+      llmFallbacks: 0,
+    };
+  }
+
   /**
    * Try to handle a subtask without LLM. Returns { handled: true } if successful.
    */
   async route(subtask: string): Promise<RouteResult> {
+    this.telemetry.totalRequests += 1;
     const rawTask = subtask.trim();
     const task = rawTask.toLowerCase();
 
@@ -100,104 +132,92 @@ export class ActionRouter {
     const separatorVerb = /(?:,\s*|\band\s+then\s+|\bthen\s+)\b(open|launch|start|type|click|tap|save|close|find|press|navigate|go to|draw|write|send|create|delete|move|drag|search|download|upload)\b/i;
     const verbAndVerb = /^(open|launch|start|type|click|tap|navigate|go to|find|press)\b.+\band\s+(open|launch|start|type|click|tap|save|close|find|press|navigate|go to|draw|write|send|create|delete|move|drag|search|download|upload)\b/i;
     if (separatorVerb.test(task) || verbAndVerb.test(task)) {
+      this.telemetry.llmFallbacks += 1;
       return { handled: false, description: 'Compound task — needs decomposition' };
     }
 
     // 1. "open [app]" / "launch [app]" / "start [app]"
     const openMatch = rawTask.match(/^(?:open|launch|start|run)\s+(\S.*)$/i);
     if (openMatch) {
+      this.telemetry.nonShortcutHandled += 1;
       return this.handleOpenApp(openMatch[1].trim());
     }
 
     // 2. "type [text]" / "type '[text]'" / "enter [text]"
     const typeMatch = rawTask.match(/^(?:type|enter|write|input)\s+(?:['"]([^'"]*)['"]\s*|(\S.*))$/i);
     if (typeMatch) {
+      this.telemetry.nonShortcutHandled += 1;
       return this.handleType(typeMatch[1] ?? typeMatch[2]);
     }
 
     // 3. "go to [url]" / "navigate to [url]" / "visit [url]"
     const urlMatch = rawTask.match(/^(?:go to|navigate to|visit|browse to|open)\s+(https?:\/\/[^\s]+|www\.[^\s]+|[^\s.]+\.\w{2,}(?:\/[^\s]*)?)$/i);
     if (urlMatch) {
+      this.telemetry.nonShortcutHandled += 1;
       return this.handleNavigateToUrl(urlMatch[1]);
     }
 
-    // 4. "press [key]" — direct key press (BEFORE click to avoid "press enter" being caught as click)
+    // 4. Shortcut registry (natural-language → fast keyboard action)
+    const shortcutContext = await this.getShortcutContextHint();
+    const shortcutMatch = findShortcut(task, PLATFORM, { contextHint: shortcutContext, enableFuzzy: true });
+    if (shortcutMatch) {
+      this.telemetry.shortcutHits += 1;
+      if (shortcutMatch.matchType === 'fuzzy') this.telemetry.shortcutFuzzyHits += 1;
+      await this.desktop.keyPress(shortcutMatch.combo);
+      return {
+        handled: true,
+        description: `Pressed ${shortcutMatch.combo} (${shortcutMatch.canonicalIntent}${shortcutMatch.matchType === 'fuzzy' ? ', fuzzy' : ''})`,
+      };
+    }
+
+    // 5. "press [key]" — direct key press (BEFORE click to avoid "press enter" being caught as click)
     const keyMatch = rawTask.match(/^(?:press|hit)\s+(\S.*)$/i);
     if (keyMatch) {
+      this.telemetry.nonShortcutHandled += 1;
       return this.handleKeyPress(keyMatch[1].trim());
     }
 
-    // 5. "click [element]" — try a11y lookup (no "press"/"hit" — handled above)
+    // 6. "click [element]" — try a11y lookup (no "press"/"hit" — handled above)
     const clickMatch = rawTask.match(
       /^(?:click|tap)\s+(?:the\s+)?(?:on\s+)?(?:['"]([^'"]+)['"]|(.+?))(?:\s+(?:button|link|tab|menu|item))?\s*$/i,
     );
     if (clickMatch) {
       const elementName = (clickMatch[1] ?? clickMatch[2] ?? '').trim();
       if (elementName) {
+        this.telemetry.nonShortcutHandled += 1;
         return this.handleClick(elementName);
       }
     }
 
-    // 6. "focus [window]" / "switch to [window]"
+    // 7. "focus [window]" / "switch to [window]"
     const focusMatch = rawTask.match(/^(?:focus|switch to|bring up|activate|go to)\s+(\S.*)$/i);
     if (focusMatch) {
+      this.telemetry.nonShortcutHandled += 1;
       return this.handleFocusWindow(focusMatch[1].trim());
     }
 
-    // 7. "close [window/app]"
+    // 8. "close [window/app]"
     const closeMatch = rawTask.match(/^(?:close)\s+(\S.*)$/i);
     if (closeMatch) {
+      this.telemetry.nonShortcutHandled += 1;
       return this.handleClose(closeMatch[1].trim());
     }
 
-    // 8. "minimize [window]" / "maximize [window]"
+    // 9. "minimize [window]" / "maximize [window]"
     const winCtrlMatch = rawTask.match(/^(minimize|maximize)\s+(\S.*)$/i);
     if (winCtrlMatch) {
+      this.telemetry.nonShortcutHandled += 1;
       return this.handleWindowControl(winCtrlMatch[1].toLowerCase(), winCtrlMatch[2].trim());
     }
 
-    // 9. "select all" / "copy" / "paste" / "undo" / "redo" / "save" + common shortcuts
-    const mod = PLATFORM === 'darwin' ? 'Super' : 'ctrl'; // Cmd on macOS, Ctrl on Windows
-    const shortcutMap: Record<string, string> = {
-      'select all': `${mod}+a`,
-      'copy': `${mod}+c`,
-      'paste': `${mod}+v`,
-      'cut': `${mod}+x`,
-      'undo': `${mod}+z`,
-      'redo': PLATFORM === 'darwin' ? 'Super+shift+z' : 'ctrl+y',
-      'save': `${mod}+s`,
-      'save as': `${mod}+shift+s`,
-      'find': `${mod}+f`,
-      'new tab': `${mod}+t`,
-      'close tab': `${mod}+w`,
-      'new window': `${mod}+n`,
-      'refresh': PLATFORM === 'darwin' ? 'Super+r' : 'F5',
-      'reload': PLATFORM === 'darwin' ? 'Super+r' : 'F5',
-      'go back': PLATFORM === 'darwin' ? 'Super+[' : 'Alt+Left',
-      'back': PLATFORM === 'darwin' ? 'Super+[' : 'Alt+Left',
-      'go forward': PLATFORM === 'darwin' ? 'Super+]' : 'Alt+Right',
-      'forward': PLATFORM === 'darwin' ? 'Super+]' : 'Alt+Right',
-      'zoom in': `${mod}+plus`,
-      'zoom out': `${mod}+minus`,
-      'page down': 'PageDown',
-      'page up': 'PageUp',
-      'home': 'Home',
-      'end': 'End',
-    };
-
-    for (const [pattern, combo] of Object.entries(shortcutMap)) {
-      if (task === pattern || task === `press ${pattern}`) {
-        await this.desktop.keyPress(combo);
-        return { handled: true, description: `Pressed ${combo} (${pattern})` };
-      }
-    }
-
     // 10. "find <text>" → Ctrl/Cmd+F then type
+    const mod = PLATFORM === 'darwin' ? 'Super' : 'Control'; // Cmd on macOS, Ctrl on Windows/Linux
     const findMatch = rawTask.match(/^(?:find|search in page|search within|search)\s+(.+)$/i);
     if (findMatch) {
       await this.desktop.keyPress(`${mod}+f`);
       await this.delay(200);
       await this.desktop.typeText(findMatch[1]);
+      this.telemetry.nonShortcutHandled += 1;
       return { handled: true, description: `Find "${findMatch[1]}"` };
     }
 
@@ -205,18 +225,21 @@ export class ActionRouter {
     if (/^(take|capture)\s+(a\s+)?screenshot$/.test(task)) {
       const combo = PLATFORM === 'darwin' ? 'Super+Shift+4' : 'Super+Shift+s';
       await this.desktop.keyPress(combo);
+      this.telemetry.nonShortcutHandled += 1;
       return { handled: true, description: `Screenshot via ${combo}` };
     }
 
     if (/^(show|go to)\s+desktop|minimize all$/.test(task)) {
       const combo = PLATFORM === 'darwin' ? 'Super+Option+m' : 'Super+d';
       await this.desktop.keyPress(combo);
+      this.telemetry.nonShortcutHandled += 1;
       return { handled: true, description: `Show desktop via ${combo}` };
     }
 
     if (/^lock\s+screen$/.test(task)) {
       const combo = PLATFORM === 'darwin' ? 'Control+Super+q' : 'Super+l';
       await this.desktop.keyPress(combo);
+      this.telemetry.nonShortcutHandled += 1;
       return { handled: true, description: `Lock screen via ${combo}` };
     }
 
@@ -225,10 +248,12 @@ export class ActionRouter {
       await this.desktop.keyPress(`${mod}+a`);
       await this.delay(100);
       await this.desktop.keyPress('Delete');
+      this.telemetry.nonShortcutHandled += 1;
       return { handled: true, description: 'Select all and delete' };
     }
 
     // Not handled — fall back to LLM
+    this.telemetry.llmFallbacks += 1;
     return { handled: false, description: `Could not route: "${subtask}"` };
   }
 
@@ -633,6 +658,17 @@ export class ActionRouter {
   }
 
   // ─── Utility ───────────────────────────────────────────────────────
+
+
+  private async getShortcutContextHint(): Promise<string> {
+    try {
+      const active = await this.a11y.getActiveWindow();
+      if (!active) return '';
+      return `${active.title} ${active.processName}`.toLowerCase();
+    } catch {
+      return '';
+    }
+  }
 
   private delay(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -1,0 +1,225 @@
+import * as os from 'os';
+
+export type ShortcutCategory =
+  | 'navigation'
+  | 'browser'
+  | 'editing'
+  | 'social'
+  | 'window'
+  | 'file'
+  | 'view'
+  | 'quick';
+
+export interface ShortcutDefinition {
+  id: string;
+  category: ShortcutCategory;
+  description: string;
+  canonicalIntent: string;
+  intents: string[];
+  contextHints?: string[];
+  keys: {
+    default: string;
+    darwin?: string;
+    linux?: string;
+    win32?: string;
+  };
+}
+
+export interface ShortcutMatch {
+  shortcut: ShortcutDefinition;
+  combo: string;
+  canonicalIntent: string;
+  matchedIntent: string;
+  matchType: 'exact' | 'fuzzy';
+}
+
+export interface ShortcutLookupOptions {
+  contextHint?: string;
+  enableFuzzy?: boolean;
+  maxDistance?: number;
+}
+
+const MOD = 'Control';
+const CMD = 'Super';
+
+export const SHORTCUTS: ShortcutDefinition[] = [
+  // Navigation
+  shortcut('scroll-down', 'navigation', 'Scroll down one page', 'scroll down', ['scroll down', 'page down', 'move down a page'], { default: 'PageDown' }),
+  shortcut('scroll-up', 'navigation', 'Scroll up one page', 'scroll up', ['scroll up', 'page up', 'move up a page'], { default: 'PageUp' }),
+  shortcut('go-top', 'navigation', 'Go to top of page', 'go to top', ['go to top', 'jump to top', 'top of page'], { default: `${MOD}+Home`, darwin: `${CMD}+Up` }),
+  shortcut('go-bottom', 'navigation', 'Go to bottom of page', 'go to bottom', ['go to bottom', 'jump to bottom', 'bottom of page'], { default: `${MOD}+End`, darwin: `${CMD}+Down` }),
+  shortcut('home', 'navigation', 'Go to line/page start', 'home', ['home', 'go home'], { default: 'Home' }),
+  shortcut('end', 'navigation', 'Go to line/page end', 'end', ['end', 'go end'], { default: 'End' }),
+
+  // Browser
+  shortcut('new-tab', 'browser', 'Open new browser tab', 'new tab', ['new tab', 'open new tab'], { default: `${MOD}+t`, darwin: `${CMD}+t` }),
+  shortcut('close-tab', 'browser', 'Close current browser tab', 'close tab', ['close tab', 'close this tab'], { default: `${MOD}+w`, darwin: `${CMD}+w` }),
+  shortcut('reopen-tab', 'browser', 'Reopen last closed tab', 'reopen tab', ['reopen tab', 'undo close tab', 'restore tab'], { default: `${MOD}+Shift+t`, darwin: `${CMD}+Shift+t` }),
+  shortcut('refresh', 'browser', 'Refresh current page', 'refresh', ['refresh', 'reload page', 'reload'], { default: 'F5', darwin: `${CMD}+r` }),
+  shortcut('hard-refresh', 'browser', 'Hard refresh current page', 'hard refresh', ['hard refresh', 'force refresh'], { default: `${MOD}+F5`, darwin: `${CMD}+Shift+r` }),
+  shortcut('go-back', 'browser', 'Go back in history', 'go back', ['go back', 'back'], { default: 'Alt+Left', darwin: `${CMD}+[` }),
+  shortcut('go-forward', 'browser', 'Go forward in history', 'go forward', ['go forward', 'forward'], { default: 'Alt+Right', darwin: `${CMD}+]` }),
+  shortcut('address-bar', 'browser', 'Focus address bar', 'focus address bar', ['focus address bar', 'url bar', 'go to address bar'], { default: `${MOD}+l`, darwin: `${CMD}+l` }),
+  shortcut('dev-tools', 'browser', 'Toggle developer tools', 'open dev tools', ['dev tools', 'open dev tools', 'toggle developer tools'], { default: `${MOD}+Shift+i`, darwin: `${CMD}+Option+i` }),
+
+  // Editing
+  shortcut('copy', 'editing', 'Copy selection', 'copy', ['copy', 'copy this'], { default: `${MOD}+c`, darwin: `${CMD}+c` }),
+  shortcut('paste', 'editing', 'Paste clipboard', 'paste', ['paste', 'paste here'], { default: `${MOD}+v`, darwin: `${CMD}+v` }),
+  shortcut('cut', 'editing', 'Cut selection', 'cut', ['cut'], { default: `${MOD}+x`, darwin: `${CMD}+x` }),
+  shortcut('undo', 'editing', 'Undo previous action', 'undo', ['undo'], { default: `${MOD}+z`, darwin: `${CMD}+z` }),
+  shortcut('redo', 'editing', 'Redo previous action', 'redo', ['redo'], { default: `${MOD}+y`, darwin: `${CMD}+Shift+z` }),
+  shortcut('select-all', 'editing', 'Select all content', 'select all', ['select all'], { default: `${MOD}+a`, darwin: `${CMD}+a` }),
+  shortcut('find', 'editing', 'Find in current context', 'find', ['find', 'search in page', 'find text'], { default: `${MOD}+f`, darwin: `${CMD}+f` }),
+  shortcut('replace', 'editing', 'Find and replace', 'replace', ['replace', 'find and replace'], { default: `${MOD}+h`, darwin: `${CMD}+Option+f` }),
+
+  // Social media (context-aware: these are risky one-key shortcuts)
+  shortcut('reddit-upvote', 'social', 'Upvote current post/comment', 'upvote', ['upvote', 'reddit upvote'], { default: 'a' }, ['reddit']),
+  shortcut('reddit-downvote', 'social', 'Downvote current post/comment', 'downvote', ['downvote', 'reddit downvote'], { default: 'z' }, ['reddit']),
+  shortcut('reddit-next', 'social', 'Move to next post', 'next post', ['next post', 'next item', 'reddit next'], { default: 'j' }, ['reddit']),
+  shortcut('reddit-prev', 'social', 'Move to previous post', 'previous post', ['previous post', 'previous item', 'reddit previous'], { default: 'k' }, ['reddit']),
+  shortcut('reddit-comments', 'social', 'Open comments', 'open comments', ['open comments', 'view comments'], { default: 'c' }, ['reddit']),
+  shortcut('reddit-save', 'social', 'Save current post', 'save post', ['save post'], { default: 's' }, ['reddit']),
+  shortcut('x-like', 'social', 'Like tweet', 'like tweet', ['like tweet', 'like post'], { default: 'l' }, ['twitter', 'x.com', 'tweet']),
+  shortcut('x-retweet', 'social', 'Retweet tweet', 'retweet', ['retweet', 'repost'], { default: 't' }, ['twitter', 'x.com', 'tweet']),
+
+  // Window management
+  shortcut('switch-app', 'window', 'Switch to next application', 'switch app', ['switch app', 'next app', 'alt tab'], { default: 'Alt+Tab', darwin: `${CMD}+Tab` }),
+  shortcut('switch-app-reverse', 'window', 'Switch to previous application', 'switch previous app', ['previous app', 'reverse app switch'], { default: 'Alt+Shift+Tab', darwin: `${CMD}+Shift+Tab` }),
+  shortcut('close-window', 'window', 'Close current window', 'close window', ['close window'], { default: 'Alt+F4', darwin: `${CMD}+q` }),
+  shortcut('minimize-window', 'window', 'Minimize current window', 'minimize window', ['minimize window'], { default: 'Super+Down', darwin: `${CMD}+m` }),
+  shortcut('maximize-window', 'window', 'Maximize current window', 'maximize window', ['maximize window'], { default: 'Super+Up', darwin: 'Control+Super+f' }),
+  shortcut('show-desktop', 'window', 'Show desktop', 'show desktop', ['show desktop', 'go to desktop', 'minimize all'], { default: 'Super+d', darwin: 'Fn+F11' }),
+
+  // File operations
+  shortcut('save', 'file', 'Save current file', 'save', ['save', 'save file'], { default: `${MOD}+s`, darwin: `${CMD}+s` }),
+  shortcut('save-as', 'file', 'Save current file as', 'save as', ['save as'], { default: `${MOD}+Shift+s`, darwin: `${CMD}+Shift+s` }),
+  shortcut('open-file', 'file', 'Open file', 'open file', ['open file'], { default: `${MOD}+o`, darwin: `${CMD}+o` }),
+  shortcut('new-file', 'file', 'Create new file', 'new file', ['new file'], { default: `${MOD}+n`, darwin: `${CMD}+n` }),
+  shortcut('print', 'file', 'Print current document', 'print', ['print', 'print page'], { default: `${MOD}+p`, darwin: `${CMD}+p` }),
+
+  // View
+  shortcut('zoom-in', 'view', 'Zoom in', 'zoom in', ['zoom in', 'increase zoom'], { default: `${MOD}+=`, darwin: `${CMD}+=` }),
+  shortcut('zoom-out', 'view', 'Zoom out', 'zoom out', ['zoom out', 'decrease zoom'], { default: `${MOD}+-`, darwin: `${CMD}+-` }),
+  shortcut('zoom-reset', 'view', 'Reset zoom', 'reset zoom', ['reset zoom', 'normal zoom'], { default: `${MOD}+0`, darwin: `${CMD}+0` }),
+  shortcut('fullscreen', 'view', 'Toggle fullscreen', 'fullscreen', ['fullscreen', 'toggle fullscreen'], { default: 'F11', darwin: `${CMD}+Control+f` }),
+
+  // Quick actions
+  shortcut('escape', 'quick', 'Cancel or close current dialog', 'press escape', ['escape', 'press escape', 'esc'], { default: 'Escape' }),
+  shortcut('enter', 'quick', 'Confirm current action', 'press enter', ['enter', 'press enter', 'return'], { default: 'Return' }),
+  shortcut('tab', 'quick', 'Move to next field', 'press tab', ['tab', 'press tab'], { default: 'Tab' }),
+  shortcut('space', 'quick', 'Toggle focused control', 'press space', ['space', 'press space', 'spacebar'], { default: 'Space' }),
+  shortcut('delete', 'quick', 'Delete selection', 'press delete', ['delete', 'press delete'], { default: 'Delete' }),
+  shortcut('system-search', 'quick', 'Open system search', 'system search', ['system search', 'open search', 'search apps'], { default: 'Super+s', darwin: `${CMD}+Space` }),
+  shortcut('lock-screen', 'quick', 'Lock current session', 'lock screen', ['lock screen'], { default: 'Super+l', darwin: 'Control+Super+q' }),
+];
+
+function shortcut(
+  id: string,
+  category: ShortcutCategory,
+  description: string,
+  canonicalIntent: string,
+  intents: string[],
+  keys: ShortcutDefinition['keys'],
+  contextHints?: string[],
+): ShortcutDefinition {
+  return { id, category, description, canonicalIntent, intents, keys, contextHints };
+}
+
+function normalizeIntent(input: string): string {
+  return input.toLowerCase().replace(/["'`]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function compactIntent(input: string): string {
+  return normalizeIntent(input).replace(/[^a-z0-9]/g, '');
+}
+
+type SupportedShortcutPlatform = 'darwin' | 'linux' | 'win32';
+
+function toSupportedPlatform(platform: NodeJS.Platform): SupportedShortcutPlatform | null {
+  if (platform === 'darwin' || platform === 'linux' || platform === 'win32') return platform;
+  return null;
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (!a.length) return b.length;
+  if (!b.length) return a.length;
+
+  const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    let diag = prev[0];
+    prev[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const tmp = prev[j];
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      prev[j] = Math.min(
+        prev[j] + 1,
+        prev[j - 1] + 1,
+        diag + cost,
+      );
+      diag = tmp;
+    }
+  }
+  return prev[b.length];
+}
+
+function contextAllowsShortcut(shortcutDef: ShortcutDefinition, normalizedInput: string, options: ShortcutLookupOptions): boolean {
+  if (!shortcutDef.contextHints?.length) return true;
+
+  const contextSource = `${normalizedInput} ${options.contextHint ?? ''}`.toLowerCase();
+  return shortcutDef.contextHints.some(hint => contextSource.includes(hint.toLowerCase()));
+}
+
+export function resolveShortcutKey(shortcutDef: ShortcutDefinition, platform: NodeJS.Platform = os.platform()): string {
+  const supported = toSupportedPlatform(platform);
+  if (!supported) return shortcutDef.keys.default;
+  return shortcutDef.keys[supported] ?? shortcutDef.keys.default;
+}
+
+export function findShortcut(
+  input: string,
+  platform: NodeJS.Platform = os.platform(),
+  options: ShortcutLookupOptions = {},
+): ShortcutMatch | null {
+  const normalized = normalizeIntent(input);
+  const compact = compactIntent(input);
+  const enableFuzzy = options.enableFuzzy ?? true;
+  const maxDistance = options.maxDistance ?? 1;
+
+  let bestFuzzy: { shortcutDef: ShortcutDefinition; intent: string; distance: number } | null = null;
+
+  for (const shortcutDef of SHORTCUTS) {
+    if (!contextAllowsShortcut(shortcutDef, normalized, options)) continue;
+
+    for (const intent of shortcutDef.intents) {
+      const normalizedIntent = normalizeIntent(intent);
+      if (normalized === normalizedIntent || normalized === `press ${normalizedIntent}`) {
+        return {
+          shortcut: shortcutDef,
+          combo: resolveShortcutKey(shortcutDef, platform),
+          canonicalIntent: shortcutDef.canonicalIntent,
+          matchedIntent: intent,
+          matchType: 'exact',
+        };
+      }
+
+      if (!enableFuzzy) continue;
+
+      const intentCompact = compactIntent(intent);
+      const distance = levenshteinDistance(compact, intentCompact);
+      if (distance <= maxDistance && (!bestFuzzy || distance < bestFuzzy.distance)) {
+        bestFuzzy = { shortcutDef, intent, distance };
+      }
+    }
+  }
+
+  if (!bestFuzzy) return null;
+
+  return {
+    shortcut: bestFuzzy.shortcutDef,
+    combo: resolveShortcutKey(bestFuzzy.shortcutDef, platform),
+    canonicalIntent: bestFuzzy.shortcutDef.canonicalIntent,
+    matchedIntent: bestFuzzy.intent,
+    matchType: 'fuzzy',
+  };
+}

--- a/test-shortcuts.js
+++ b/test-shortcuts.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const { findShortcut } = require('./dist/shortcuts');
+
+const samples = [
+  ['scroll down'],
+  ['go to top'],
+  ['newtab'],
+  ['refesh'],
+  ['upvote'],
+  ['upvote', { contextHint: 'reddit.com feed' }],
+  ['lock screen'],
+  ['non matching intent'],
+];
+
+for (const [input, options] of samples) {
+  const match = findShortcut(input, process.platform, options);
+  if (!match) {
+    console.log(`${input} -> no match`);
+    continue;
+  }
+
+  console.log(`${input} -> ${match.combo} (${match.canonicalIntent}, ${match.matchType})`);
+}

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { findShortcut, resolveShortcutKey, SHORTCUTS } from '../src/shortcuts';
+
+describe('shortcuts registry', () => {
+  it('matches common natural language intents', () => {
+    expect(findShortcut('scroll down', 'linux')?.combo).toBe('PageDown');
+    expect(findShortcut('new tab', 'linux')?.combo).toBe('Control+t');
+    expect(findShortcut('reddit upvote', 'linux')?.combo).toBe('a');
+  });
+
+  it('supports press-prefixed intents', () => {
+    const match = findShortcut('press refresh', 'win32');
+    expect(match?.combo).toBe('F5');
+    expect(match?.canonicalIntent).toBe('refresh');
+    expect(match?.matchType).toBe('exact');
+  });
+
+  it('uses platform-specific variants', () => {
+    const refresh = SHORTCUTS.find(s => s.id === 'refresh');
+    expect(refresh).toBeTruthy();
+    expect(resolveShortcutKey(refresh!, 'darwin')).toBe('Super+r');
+    expect(resolveShortcutKey(refresh!, 'linux')).toBe('F5');
+  });
+
+  it('supports fuzzy matching for minor typos', () => {
+    const fuzzyRefresh = findShortcut('refesh', 'linux');
+    expect(fuzzyRefresh?.combo).toBe('F5');
+    expect(fuzzyRefresh?.matchType).toBe('fuzzy');
+
+    const fuzzyNewTab = findShortcut('newtab', 'linux');
+    expect(fuzzyNewTab?.combo).toBe('Control+t');
+  });
+
+  it('applies context-aware constraints for social shortcuts', () => {
+    expect(findShortcut('upvote', 'linux')).toBeNull();
+
+    const socialFromContext = findShortcut('upvote', 'linux', { contextHint: 'reddit.com frontpage' });
+    expect(socialFromContext?.combo).toBe('a');
+
+    const socialFromTask = findShortcut('reddit upvote', 'linux');
+    expect(socialFromTask?.combo).toBe('a');
+  });
+
+  it('returns null for unknown intents', () => {
+    expect(findShortcut('dance now')).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a centralized shortcut registry to map natural-language intents to OS-specific keyboard combos so many desktop tasks can be handled without LLM calls.
- Make single-key social shortcuts safe via context hints and add fuzzy matching to tolerate small typos.
- Instrument the action router to measure shortcut usage vs LLM fallbacks to evaluate keyboard-first routing effectiveness.

### Description

- Add `src/shortcuts.ts` implementing `SHORTCUTS`, `findShortcut`, `resolveShortcutKey`, fuzzy matching via Levenshtein distance, context-aware constraints, and platform-specific key variants.
- Integrate the registry into `src/action-router.ts` by calling `findShortcut(...)` early in `route()`, performing `desktop.keyPress(...)` on match, and adding `getTelemetry()` / `resetTelemetry()` plus a `RouterTelemetry` object tracking `totalRequests`, `shortcutHits`, `shortcutFuzzyHits`, `nonShortcutHandled`, and `llmFallbacks`.
- Remove the old inline shortcut map in `route()` (replaced by registry lookups), add `getShortcutContextHint()` to source active-window info for context-aware shortcuts, and update modifier naming to use `Control`/`Super` consistently.
- Add documentation and demo files: `AI-SHORTCUTS.md` and `shortcut-demo.md`, plus a simple CLI tester `test-shortcuts.js`.

### Testing

- Added unit tests in `tests/shortcuts.test.ts` covering exact matches, press-prefixed intents, platform variants, fuzzy matching, and context constraints, and ran them with `vitest` which succeeded.
- Ran the ad-hoc CLI check `node test-shortcuts.js` against the built `dist/shortcuts` which produced expected matches for the sample inputs.
- No existing tests were modified and the new tests pass on the CI/test environment used for this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30c8ee99883279620e004861facaf)