### PR TITLE
Infer provider labels and add loop-guard to ComputerUseBrain

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -40,7 +40,7 @@ import { A11yReasoner } from './a11y-reasoner';
 import { BrowserLayer } from './browser-layer';
 import { SmartInteractionLayer } from './smart-interaction';
 import { loadPipelineConfig } from './doctor';
-import type { PipelineConfig } from './providers';
+import { detectProvider, type PipelineConfig } from './providers';
 import type { ClawdConfig, AgentState, TaskResult, StepResult, InputAction, A11yAction } from './types';
 
 const MAX_STEPS = 15;
@@ -116,11 +116,54 @@ export class Agent {
     }
   }
 
+  private inferProviderLabel(apiKey?: string, baseUrl?: string, fallback?: string): string {
+    const inferredFromUrl = this.inferProviderFromBaseUrl(baseUrl);
+    if (inferredFromUrl) return inferredFromUrl;
+
+    if (apiKey && apiKey.length > 0) {
+      return detectProvider(apiKey, fallback);
+    }
+
+    return fallback || 'unknown';
+  }
+
+  private inferProviderFromBaseUrl(baseUrl?: string): string | null {
+    const url = (baseUrl || '').toLowerCase();
+    if (!url) return null;
+    if (url.includes('anthropic')) return 'anthropic';
+    if (url.includes('moonshot') || url.includes('kimi')) return 'kimi';
+    if (url.includes('11434') || url.includes('ollama')) return 'ollama';
+    if (url.includes('openai')) return 'openai';
+    if (url.includes('groq')) return 'groq';
+    if (url.includes('together')) return 'together';
+    if (url.includes('deepseek')) return 'deepseek';
+    if (url.includes('nvidia') || url.includes('integrate.api')) return 'nvidia';
+    if (url.includes('mistral')) return 'mistral';
+    if (url.includes('fireworks')) return 'fireworks';
+    return null;
+  }
+
   async connect(): Promise<void> {
     await this.desktop.connect();
 
     // Initialize Browser Layer (Layer 0) — Playwright for browser tasks
     const pipelineConfig = loadPipelineConfig();
+    const textModel = this.config.ai.model || pipelineConfig?.layer2?.model || 'unavailable';
+    const visionModel = this.config.ai.visionModel || pipelineConfig?.layer3?.model || 'unavailable';
+
+    const textProvider = this.inferProviderLabel(
+      this.config.ai.textApiKey || this.config.ai.apiKey,
+      this.config.ai.textBaseUrl || this.config.ai.baseUrl || pipelineConfig?.layer2?.baseUrl,
+      this.config.ai.provider,
+    );
+    const visionProvider = this.inferProviderLabel(
+      this.config.ai.visionApiKey || this.config.ai.apiKey,
+      this.config.ai.visionBaseUrl || this.config.ai.baseUrl || pipelineConfig?.layer3?.baseUrl,
+      this.config.ai.provider,
+    );
+
+    console.log(`🤖 Active models: text=${textModel} (${textProvider}) | vision=${visionModel} (${visionProvider})`);
+
     this.browserLayer = new BrowserLayer(this.config, pipelineConfig || {} as PipelineConfig);
     console.log(`🌐 Layer 0 (Browser): Playwright — CDP or managed Chromium`);
 

--- a/src/computer-use.ts
+++ b/src/computer-use.ts
@@ -212,6 +212,8 @@ export class ComputerUseBrain {
 
     let consecutiveErrors = 0;
     const MAX_CONSECUTIVE_ERRORS = 5;
+    let lastActionSignature = '';
+    let repeatedActionStreak = 0;
 
     for (let i = 0; i < MAX_ITERATIONS; i++) {
       llmCalls++;
@@ -408,30 +410,49 @@ export class ComputerUseBrain {
           // Track consecutive errors for bail-out
           if (result.error) {
             consecutiveErrors++;
+            lastActionSignature = '';
+            repeatedActionStreak = 0;
             if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
               console.log(`   ❌ ${MAX_CONSECUTIVE_ERRORS} consecutive errors — aborting task`);
               return { success: false, steps, llmCalls };
             }
           } else {
             consecutiveErrors = 0;
+            const signature = this.actionSignature(toolUse);
+            if (signature && signature === lastActionSignature) {
+              repeatedActionStreak++;
+            } else {
+              lastActionSignature = signature;
+              repeatedActionStreak = signature ? 1 : 0;
+            }
           }
 
-          if (result.error) {
-            // Always send full context on error so Claude can recover
+          const loopDetected = !result.error && repeatedActionStreak >= 4;
+
+          if (result.error || loopDetected) {
+            // Always send full context on error or loop detection so Claude can recover
             const [screenshot, a11yContext] = await Promise.all([
               this.desktop.captureForLLM(),
               this.getA11yContext(true, skipA11yCompletely),
             ]);
             if (debugDir) this.saveDebugScreenshot(screenshot.buffer, debugDir, subtaskIndex, i, action);
+            const loopHint = loopDetected
+              ? `Loop guard: repeated the same action ${repeatedActionStreak} times (${lastActionSignature}). STOP repeating. Use a different strategy (refocus target app/tab, navigate back/home, or choose a different element).`
+              : '';
             toolResults.push({
               type: 'tool_result',
               tool_use_id: toolUse.id,
               content: [
-                { type: 'text', text: `Error: ${result.error}` },
+                { type: 'text', text: result.error ? `Error: ${result.error}` : loopHint },
                 this.screenshotToContent(screenshot),
                 { type: 'text', text: a11yContext },
               ],
             });
+            if (loopDetected) {
+              console.log(`   ♻️  Loop guard: repeated action detected — forcing recovery context`);
+              repeatedActionStreak = 0;
+              lastActionSignature = '';
+            }
           } else if (isLastInBatch) {
             // Last action in batch: full screenshot + optional a11y
             const isNavigation = action === 'key' && toolUse.input.text?.toLowerCase().includes('return');
@@ -703,6 +724,21 @@ export class ComputerUseBrain {
     const hasScreenshot = /\b(screenshot|take a screenshot)\b/.test(t);
     const hasWaitRespond = /\b(wait for.*(respond|response)|monitor progress)\b/.test(t);
     return (hasLoop && hasScreenshot) || (hasLoop && hasWaitRespond);
+  }
+
+
+  /** Build a compact signature used to detect repeated no-progress action loops. */
+  private actionSignature(toolUse: ToolUseBlock): string {
+    const { action, coordinate, text, key, scroll_direction, scroll_amount } = toolUse.input;
+
+    // Focus on actions that commonly loop when the model gets stuck.
+    const loopProne = new Set(['left_click', 'right_click', 'double_click', 'scroll', 'key', 'mouse_move']);
+    if (!loopProne.has(action)) return '';
+
+    const coordPart = coordinate ? `${coordinate[0]},${coordinate[1]}` : '';
+    const textPart = (text || key || '').toLowerCase().trim().slice(0, 40);
+    const scrollPart = action === 'scroll' ? `${scroll_direction || 'down'}:${scroll_amount || 3}` : '';
+    return `${action}|${coordPart}|${textPart}|${scrollPart}`;
   }
 
   /**


### PR DESCRIPTION
### Motivation

- Improve visibility of which text/vision providers and models are active for better diagnostics and user messaging. 
- Prevent the agent from getting stuck repeating the same no-progress actions by detecting loops and forcing recovery.

### Description

- Added `detectProvider` import and implemented `inferProviderLabel` and `inferProviderFromBaseUrl` in `src/agent.ts` to infer provider names from API keys, base URLs, or fallback provider values and log active `text` / `vision` model + provider pairs. 
- Enhanced `connect()` logging to print `textModel` and `visionModel` along with inferred `textProvider` and `visionProvider`. 
- Introduced loop-detection state (`lastActionSignature`, `repeatedActionStreak`) and recovery behavior in `src/computer-use.ts` to identify repeated actions and treat them like errors so the LLM receives full context to recover. 
- Added `actionSignature` helper to build compact signatures for loop-prone actions and emit a `loopHint` in the `tool_result` content when a loop is detected, and reset streak state after forcing recovery.

### Testing

- Ran a TypeScript type-check and build with `npm run build`, which succeeded. 
- Ran unit tests with `npm test`, which passed. 
- Ran linter with `npm run lint`, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30d1d382083278011543adaf71425)