### PR TITLE
Register global `clawdcursor` CLI in skill install instructions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -22,9 +22,9 @@ metadata:
     requires: {}
     install:
       - git clone https://github.com/AmrDab/clawd-cursor.git
-      - cd clawd-cursor && npm install && npm run build
-      - cd clawd-cursor && npx clawd-cursor doctor
-      - cd clawd-cursor && npm start
+      - cd clawd-cursor && npm install && npm run setup
+      - cd clawd-cursor && clawdcursor doctor
+      - cd clawd-cursor && clawdcursor start
     privacy:
       - Screenshots processed by user's own configured AI provider only
       - With Ollama, fully offline — no external API calls


### PR DESCRIPTION
### Motivation
- Ensure the documented install flow for the skill registers the CLI globally so users who clone the repo can run `clawdcursor` without `npx` or manual steps.

### Description
- Updated the `install` block in `SKILL.md` to run `npm run setup` (which includes `npm link`) instead of `npm run build` so the CLI is registered globally.
- Replaced follow-up example invocations with the global CLI (`clawdcursor doctor` and `clawdcursor start`) to match the new setup flow.

### Testing
- Verified the updated install lines in `SKILL.md` using `nl -ba SKILL.md | sed -n '18,35p'` and confirmed the new commands appear as expected, which succeeded.
- Inspected `package.json` with `cat package.json` to confirm the `bin` entries expose `clawdcursor`, which succeeded.
- Used `rg` to search README and docs to ensure references to setup/usage are consistent, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a328cc513883279174fe9f7ceec3fc)