### PR TITLE
Enhance OpenClaw provider detection and env-var resolution; add tests

### DIFF
--- a/src/openclaw-credentials.ts
+++ b/src/openclaw-credentials.ts
@@ -47,6 +47,14 @@ function normalizeProvider(provider?: string): string | undefined {
   return p.length > 0 ? p : undefined;
 }
 
+function toEnvStyleKey(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/^_+|_+$/g, '')
+    .toUpperCase();
+}
+
 function normalizeBaseUrl(url?: string): string | undefined {
   if (!url) return undefined;
   const trimmed = url.trim().replace(/\/+$/, '');
@@ -114,6 +122,36 @@ function extractApiKeyLike(value: any): string | undefined {
   return undefined;
 }
 
+function resolveTemplateVars(value: string, envSources: Array<Record<string, any> | undefined>): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const hasTemplate = /\$\{[^}]+\}/.test(trimmed);
+  if (!hasTemplate) return trimmed;
+
+  let unresolved = false;
+  const expanded = trimmed.replace(/\$\{([^}]+)\}/g, (_, key: string) => {
+    const normalizedKey = key.trim();
+    for (const source of envSources) {
+      const candidate = source?.[normalizedKey];
+      if (typeof candidate === 'string' && candidate.length > 0) {
+        return candidate;
+      }
+    }
+    unresolved = true;
+    return '';
+  });
+
+  if (unresolved) return undefined;
+  return expanded;
+}
+
+function extractResolvedApiKey(value: any, envSources: Array<Record<string, any> | undefined>): string | undefined {
+  const apiKey = extractApiKeyLike(value);
+  if (!apiKey) return undefined;
+  return resolveTemplateVars(apiKey, envSources);
+}
+
 function extractBaseUrlLike(value: any): string | undefined {
   if (!value) return undefined;
   if (typeof value === 'string') return normalizeBaseUrl(value);
@@ -143,6 +181,31 @@ function getOpenClawRoots(): string[] {
     path.join(home, '.openclaw'),
     path.join(home, '.openclaw-dev'),
   ];
+}
+
+function readConfiguredProvider(): string | undefined {
+  const configPath = path.join(process.cwd(), '.clawd-config.json');
+  const cfg = safeReadJson(configPath);
+  if (!cfg || !isObject(cfg)) return undefined;
+
+  const provider = pick(cfg.provider, cfg?.pipeline?.provider, cfg?.pipeline?.providerKey);
+  return normalizeProvider(provider);
+}
+
+function providerEnvCandidates(provider?: string): string[] {
+  const normalized = normalizeProvider(provider);
+  if (!normalized) return [];
+
+  const bases = [normalized, normalized.split(':')[0]].filter(Boolean);
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const base of bases) {
+    const envBase = toEnvStyleKey(base);
+    if (!envBase || seen.has(envBase)) continue;
+    seen.add(envBase);
+    keys.push(`${envBase}_API_KEY`);
+  }
+  return keys;
 }
 
 function loadOpenClawProviderMap(): Record<string, ProviderInfo> {
@@ -197,6 +260,8 @@ function loadOpenClawProviderMap(): Record<string, ProviderInfo> {
       const cfg = safeReadJson(configPath);
       if (!cfg) continue;
 
+      const envSources = [cfg.env, process.env];
+
       const providerBlocks = [
         cfg?.models?.providers,
         cfg?.providers,
@@ -206,7 +271,7 @@ function loadOpenClawProviderMap(): Record<string, ProviderInfo> {
         if (!isObject(block)) continue;
         for (const [key, value] of Object.entries(block)) {
           const entry = ensureProvider(key);
-          const apiKey = extractApiKeyLike(value);
+          const apiKey = extractResolvedApiKey(value, envSources);
           const baseUrl = extractBaseUrlLike(value);
           if (apiKey && !entry.apiKey) entry.apiKey = apiKey;
           if (baseUrl && !entry.baseUrl) entry.baseUrl = baseUrl;
@@ -245,8 +310,8 @@ function selectVisionProvider(providers: ProviderInfo[]): ProviderInfo | null {
 }
 
 function selectTextProvider(providers: ProviderInfo[]): ProviderInfo | null {
-  const ollama = providers.find(p => p.key === 'ollama' && p.models.length > 0);
-  if (ollama) return ollama;
+  const withTextModel = providers.find(p => p.models.some(m => !m.input.includes('image') && !m.input.includes('vision')));
+  if (withTextModel) return withTextModel;
   return providers.find(p => p.models.length > 0) || null;
 }
 
@@ -255,10 +320,14 @@ function resolveFromOpenClawFiles(): ResolvedApiConfig | null {
   const providerList = Object.values(providerMap).filter(p => !!(p.apiKey || p.baseUrl || p.models.length > 0));
   if (providerList.length === 0) return null;
 
-  const visionProvider = selectVisionProvider(providerList);
-  const textProvider = selectTextProvider(providerList);
+  const configuredProvider = readConfiguredProvider();
+  const preferredProvider = configuredProvider ? providerMap[configuredProvider] : undefined;
+  const preferredCandidates = preferredProvider ? [preferredProvider] : providerList;
 
-  const selectedProvider = visionProvider || textProvider;
+  const visionProvider = selectVisionProvider(preferredCandidates) || selectVisionProvider(providerList);
+  const textProvider = selectTextProvider(preferredCandidates) || selectTextProvider(providerList);
+
+  const selectedProvider = preferredProvider || visionProvider || textProvider;
   if (!selectedProvider) return null;
 
   const visionModel = visionProvider?.models.find(m => m.input.includes('image') || m.input.includes('vision'))?.id
@@ -266,14 +335,32 @@ function resolveFromOpenClawFiles(): ResolvedApiConfig | null {
   const textModel = textProvider?.models.find(m => !m.input.includes('image') && !m.input.includes('vision'))?.id
     || textProvider?.models[0]?.id;
 
+  const resolvedApiKey = selectedProvider.apiKey
+    || textProvider?.apiKey
+    || visionProvider?.apiKey
+    || providerList.find(p => !!p.apiKey)?.apiKey
+    || '';
+
+  const isLikelyLocalProvider = (provider: ProviderInfo | undefined): boolean => {
+    const url = (provider?.baseUrl || '').toLowerCase();
+    return provider?.key === 'ollama' || url.includes('localhost') || url.includes('127.0.0.1') || url.includes('11434');
+  };
+
+  if (!resolvedApiKey && !isLikelyLocalProvider(selectedProvider)) {
+    return null;
+  }
+
+  const resolvedTextApiKey = textProvider?.apiKey || selectedProvider.apiKey || resolvedApiKey;
+  const resolvedVisionApiKey = visionProvider?.apiKey || selectedProvider.apiKey || resolvedApiKey;
+
   return {
-    apiKey: visionProvider?.apiKey || selectedProvider.apiKey || textProvider?.apiKey || '',
+    apiKey: resolvedApiKey,
     baseUrl: visionProvider?.baseUrl || selectedProvider.baseUrl || textProvider?.baseUrl,
     textModel,
     visionModel,
-    textApiKey: textProvider?.apiKey,
+    textApiKey: resolvedTextApiKey,
     textBaseUrl: textProvider?.baseUrl,
-    visionApiKey: visionProvider?.apiKey || selectedProvider.apiKey,
+    visionApiKey: resolvedVisionApiKey,
     visionBaseUrl: visionProvider?.baseUrl || selectedProvider.baseUrl,
     provider: normalizeProvider(selectedProvider.key) || inferProviderFromBaseUrl(selectedProvider.baseUrl),
     source: 'openclaw',
@@ -362,32 +449,40 @@ export function resolveApiConfig(opts?: {
   }
 
   const explicitApiKey = opts?.apiKey || '';
+  const localProvider = normalizeProvider(opts?.provider) || normalizeProvider(readConfiguredProvider());
+  const providerScopedEnvKey = pick(
+    ...providerEnvCandidates(localProvider).map((key) => {
+      const value = process.env[key];
+      return typeof value === 'string' ? value : undefined;
+    }),
+  );
   const localBaseUrl = normalizeBaseUrl(pick(opts?.baseUrl, process.env.AI_BASE_URL, process.env.OPENAI_BASE_URL));
   const localTextModel = pick(opts?.textModel, process.env.AI_TEXT_MODEL, process.env.AI_MODEL);
   const localVisionModel = pick(opts?.visionModel, process.env.AI_VISION_MODEL, process.env.AI_MODEL);
-
-  if (explicitApiKey || localBaseUrl || localTextModel || localVisionModel || opts?.provider) {
-    return {
-      apiKey: explicitApiKey,
-      provider: normalizeProvider(opts?.provider) || inferProviderFromBaseUrl(localBaseUrl),
-      baseUrl: localBaseUrl,
-      textModel: localTextModel,
-      visionModel: localVisionModel,
-      textApiKey: explicitApiKey,
-      textBaseUrl: localBaseUrl,
-      visionApiKey: explicitApiKey,
-      visionBaseUrl: localBaseUrl,
-      source: 'local',
-    };
-  }
-
   const localApiKey = pick(
+    explicitApiKey,
     process.env.AI_API_KEY,
+    providerScopedEnvKey,
     process.env.ANTHROPIC_API_KEY,
     process.env.OPENAI_API_KEY,
     process.env.KIMI_API_KEY,
     process.env.MOONSHOT_API_KEY,
   ) || '';
+
+  if (localApiKey || localBaseUrl || localTextModel || localVisionModel || opts?.provider) {
+    return {
+      apiKey: localApiKey,
+      provider: normalizeProvider(opts?.provider) || inferProviderFromBaseUrl(localBaseUrl),
+      baseUrl: localBaseUrl,
+      textModel: localTextModel,
+      visionModel: localVisionModel,
+      textApiKey: localApiKey,
+      textBaseUrl: localBaseUrl,
+      visionApiKey: localApiKey,
+      visionBaseUrl: localBaseUrl,
+      source: 'local',
+    };
+  }
 
   return {
     apiKey: localApiKey,

--- a/tests/openclaw-credentials.test.ts
+++ b/tests/openclaw-credentials.test.ts
@@ -1,0 +1,130 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveApiConfig } from '../src/openclaw-credentials';
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+describe.sequential('openclaw credential resolution', () => {
+  const originalCwd = process.cwd();
+  const originalHome = os.homedir();
+
+  let tempRoot: string;
+  let tempHome: string;
+  let tempCwd: string;
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'clawd-credentials-'));
+    tempHome = path.join(tempRoot, 'home');
+    tempCwd = path.join(tempRoot, 'project');
+    fs.mkdirSync(tempHome, { recursive: true });
+    fs.mkdirSync(tempCwd, { recursive: true });
+
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    process.chdir(tempCwd);
+
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENCLAW_AI_API_KEY;
+    delete process.env.AI_API_KEY;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalHome;
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('resolves ${ENV_VAR} placeholders from openclaw.json env block', () => {
+    writeJson(path.join(tempHome, '.openclaw', 'openclaw.json'), {
+      env: {
+        MOONSHOT_API_KEY: 'moonshot-real-key',
+      },
+      models: {
+        providers: {
+          moonshot: {
+            apiKey: '${MOONSHOT_API_KEY}',
+            baseUrl: 'https://api.moonshot.ai/v1',
+            models: [{ id: 'moonshot-v1-vision', input: ['image'] }],
+          },
+        },
+      },
+    });
+
+    const resolved = resolveApiConfig();
+    expect(resolved.source).toBe('openclaw');
+    expect(resolved.apiKey).toBe('moonshot-real-key');
+    expect(resolved.visionApiKey).toBe('moonshot-real-key');
+  });
+
+  it('prefers doctor-configured provider from .clawd-config.json', () => {
+    writeJson(path.join(tempHome, '.openclaw', 'openclaw.json'), {
+      env: {
+        MOONSHOT_API_KEY: 'moonshot-real-key',
+      },
+      models: {
+        providers: {
+          moonshot: {
+            apiKey: '${MOONSHOT_API_KEY}',
+            baseUrl: 'https://api.moonshot.ai/v1',
+            models: [{ id: 'moonshot-v1-vision', input: ['image'] }],
+          },
+          anthropic: {
+            apiKey: 'anthropic-live-key',
+            baseUrl: 'https://api.anthropic.com/v1',
+            models: [{ id: 'claude-sonnet-4-5', input: ['text'] }],
+          },
+        },
+      },
+    });
+
+    writeJson(path.join(tempCwd, '.clawd-config.json'), {
+      provider: 'anthropic',
+    });
+
+    const resolved = resolveApiConfig();
+    expect(resolved.source).toBe('openclaw');
+    expect(resolved.provider).toBe('anthropic');
+    expect(resolved.apiKey).toBe('anthropic-live-key');
+    expect(resolved.textApiKey).toBe('anthropic-live-key');
+  });
+
+  it('falls back to env keys when openclaw provider key is unresolved', () => {
+    process.env.ANTHROPIC_API_KEY = 'env-anthropic-key';
+
+    writeJson(path.join(tempHome, '.openclaw', 'openclaw.json'), {
+      models: {
+        providers: {
+          moonshot: {
+            apiKey: '${MOONSHOT_API_KEY}',
+            baseUrl: 'https://api.moonshot.ai/v1',
+            models: [{ id: 'moonshot-v1', input: ['text'] }],
+          },
+        },
+      },
+    });
+
+    const resolved = resolveApiConfig();
+    expect(resolved.source).toBe('local');
+    expect(resolved.apiKey).toBe('env-anthropic-key');
+  });
+
+  it('supports provider-scoped env keys for arbitrary providers', () => {
+    process.env.MY_CUSTOM_PROVIDER_API_KEY = 'custom-provider-key';
+
+    writeJson(path.join(tempCwd, '.clawd-config.json'), {
+      provider: 'my-custom-provider',
+    });
+
+    const resolved = resolveApiConfig();
+    expect(resolved.source).toBe('local');
+    expect(resolved.apiKey).toBe('custom-provider-key');
+    expect(resolved.textApiKey).toBe('custom-provider-key');
+    expect(resolved.visionApiKey).toBe('custom-provider-key');
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve detection and resolution of API keys and providers coming from OpenClaw config files, environment variables, and project-local config, including support for template placeholders like `${ENV_VAR}`. 
- Allow provider-scoped environment variables (e.g. `MY_PROVIDER_API_KEY`) and prefer a doctor-configured provider from `.clawd-config.json` when present. 
- Make selection logic more robust for text vs vision providers and allow local (localhost/ollama) providers without an API key.

### Description

- Added `toEnvStyleKey`, `resolveTemplateVars`, `extractResolvedApiKey`, `readConfiguredProvider`, and `providerEnvCandidates` helpers to normalize env keys and expand `${...}` placeholders against `openclaw.json` `env` block and `process.env`.
- Updated `loadOpenClawProviderMap` to resolve templated API keys using the config `env` block and to prefer resolved keys when loading providers from OpenClaw files.
- Improved provider selection logic to pick providers with text-capable models first and to honor a configured provider from `.clawd-config.json` when present.
- Added logic to consider a provider 'local' (e.g. `ollama` or `localhost`) so an absence of API keys is allowed for local providers, and consolidated resolution of text/vision API key fallbacks.
- Added provider-scoped environment variable lookup into `resolveApiConfig` so keys like `MY_CUSTOM_PROVIDER_API_KEY` are considered for matching configured providers.
- Created unit tests in `tests/openclaw-credentials.test.ts` covering `${ENV_VAR}` expansion from `openclaw.json`, honoring `.clawd-config.json` provider preference, falling back to env keys, and provider-scoped env key support.

### Testing

- Ran the test suite with `vitest` for the new `openclaw-credentials` tests; all tests in `tests/openclaw-credentials.test.ts` passed.
- Verified no regressions in credential resolution by running `vitest` for the repository test suite, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39d5824fc8327813a13352248766c)