### PR TITLE
Add pipeline-specific Computer Use overrides and provider-aware defaults

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -204,9 +204,18 @@ export class Agent {
       console.log(`🧩 Layer 1.5 (Smart Interaction): CDPDriver + UIDriver — 1 LLM call planning`);
     }
 
-    // Initialize Computer Use if Anthropic provider
-    if (ComputerUseBrain.isSupported(this.config)) {
-      this.computerUse = new ComputerUseBrain(this.config, this.desktop, this.a11y, this.safety);
+    // Initialize Computer Use for Anthropic or mixed-provider pipeline overrides
+    const computerUseOverrides = pipelineConfig?.layer3?.computerUse
+      ? {
+          enabled: pipelineConfig.layer3.computerUse,
+          apiKey: pipelineConfig.layer3.apiKey,
+          model: pipelineConfig.layer3.model,
+          baseUrl: pipelineConfig.layer3.baseUrl,
+        }
+      : undefined;
+
+    if (ComputerUseBrain.isSupported(this.config, computerUseOverrides)) {
+      this.computerUse = new ComputerUseBrain(this.config, this.desktop, this.a11y, this.safety, computerUseOverrides);
       console.log(`🖥️  Computer Use API enabled (Anthropic native tool + accessibility)`);
     }
 

--- a/src/computer-use.ts
+++ b/src/computer-use.ts
@@ -392,6 +392,13 @@ export interface ComputerUseResult {
   llmCalls: number;
 }
 
+export interface ComputerUseOverrides {
+  apiKey?: string;
+  model?: string;
+  baseUrl?: string;
+  enabled?: boolean;
+}
+
 /** How long to reuse a cached a11y context before re-fetching (ms) */
 const A11Y_CACHE_TTL = 30_000;
 
@@ -408,15 +415,23 @@ export class ComputerUseBrain {
   private heldKeys: string[] = [];
   private lastMouseX = 0;
   private lastMouseY = 0;
+  private computerUseOverrides?: ComputerUseOverrides;
 
   // A11y context cache — avoids hammering JXA after every single action
   private a11yCache: { context: string; ts: number; pid?: number } | null = null;
 
-  constructor(config: ClawdConfig, desktop: NativeDesktop, a11y: AccessibilityBridge, safety: SafetyLayer) {
+  constructor(
+    config: ClawdConfig,
+    desktop: NativeDesktop,
+    a11y: AccessibilityBridge,
+    safety: SafetyLayer,
+    pipelineOverrides?: ComputerUseOverrides,
+  ) {
     this.config = config;
     this.desktop = desktop;
     this.a11y = a11y;
     this.safety = safety;
+    this.computerUseOverrides = pipelineOverrides;
 
     const screen = desktop.getScreenSize();
     this.screenWidth = screen.width;
@@ -434,8 +449,10 @@ export class ComputerUseBrain {
   /**
    * Check if the current provider supports native Computer Use.
    */
-  static isSupported(config: ClawdConfig): boolean {
-    return config.ai.provider === 'anthropic' && !!config.ai.apiKey;
+  static isSupported(config: ClawdConfig, pipelineOverrides?: ComputerUseOverrides): boolean {
+    const hasPipelineCu = !!pipelineOverrides?.enabled && !!pipelineOverrides?.apiKey;
+    const hasDirectAnthropic = config.ai.provider === 'anthropic' && !!config.ai.apiKey;
+    return hasPipelineCu || hasDirectAnthropic;
   }
 
   /**
@@ -855,16 +872,25 @@ Fix the specific missed step. Do NOT repeat steps that already succeeded.`,
       const timeout = setTimeout(() => controller.abort(), 120_000); // 2 min timeout
 
       try {
-        const response = await fetch('https://api.anthropic.com/v1/messages', {
+        const baseUrl = (this.computerUseOverrides?.baseUrl || 'https://api.anthropic.com/v1').replace(/\/+$/, '');
+        const endpoint = `${baseUrl}/messages`;
+        const apiKey = this.computerUseOverrides?.apiKey || this.config.ai.apiKey;
+        const model = this.computerUseOverrides?.model || this.config.ai.visionModel;
+
+        if (!apiKey) {
+          return { content: [], stop_reason: 'end_turn', error: 'Missing API key for Computer Use provider' };
+        }
+
+        const response = await fetch(endpoint, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'x-api-key': this.config.ai.apiKey!,
+            'x-api-key': apiKey,
             'anthropic-version': '2023-06-01',
             'anthropic-beta': BETA_HEADER,
           },
           body: JSON.stringify({
-            model: this.config.ai.visionModel,
+            model,
             max_tokens: 2048,
             system: SYSTEM_PROMPT,
             tools: [{

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1330,23 +1330,43 @@ async function testModel(
 /**
  * Load saved pipeline config from disk.
  */
+function resolveProviderApiKey(providerKey: string, fallbackApiKey?: string): string {
+  const normalizedProvider = (providerKey || '').toLowerCase();
+  if (!normalizedProvider) return fallbackApiKey || '';
+
+  const resolved = resolveApiConfig({ provider: normalizedProvider });
+  if (resolved.apiKey) return resolved.apiKey;
+
+  return fallbackApiKey || '';
+}
+
 export function loadPipelineConfig(): PipelineConfig | null {
-  const configPath = path.join(process.cwd(), CONFIG_FILE);
+  const pkgDir = path.resolve(__dirname, '..');
+  let configPath = path.join(pkgDir, CONFIG_FILE);
+
+  if (!fs.existsSync(configPath)) {
+    configPath = path.join(process.cwd(), CONFIG_FILE);
+  }
+
   try {
     if (!fs.existsSync(configPath)) return null;
     const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     const providerKey = raw.provider || 'ollama';
     const provider = PROVIDERS[providerKey] || PROVIDERS['ollama'];
-    const apiKey = resolveApiConfig().apiKey;
+    const resolvedDefault = resolveApiConfig();
+    const defaultApiKey = resolvedDefault.apiKey;
 
     // Support mixed-provider configs saved by the new doctor
     const layer2BaseUrl = raw.pipeline?.layer2?.baseUrl ?? provider.baseUrl;
     const layer3BaseUrl = raw.pipeline?.layer3?.baseUrl ?? provider.baseUrl;
+    const layer3ProviderKey = raw.pipeline?.layer3?.provider || providerKey;
+    const layer3ComputerUse = raw.pipeline?.layer3?.computerUse ?? false;
+    const explicitLayer3ApiKey = raw.pipeline?.layer3?.apiKey;
 
     return {
       provider,
       providerKey,
-      apiKey,
+      apiKey: defaultApiKey,
       layer1: true,
       layer2: {
         enabled: raw.pipeline?.layer2?.enabled ?? false,
@@ -1357,7 +1377,10 @@ export function loadPipelineConfig(): PipelineConfig | null {
         enabled: raw.pipeline?.layer3?.enabled ?? false,
         model: raw.pipeline?.layer3?.model ?? provider.visionModel,
         baseUrl: layer3BaseUrl,
-        computerUse: raw.pipeline?.layer3?.computerUse ?? false,
+        computerUse: layer3ComputerUse,
+        apiKey: layer3ComputerUse
+          ? (explicitLayer3ApiKey || resolveProviderApiKey(layer3ProviderKey, defaultApiKey))
+          : undefined,
       },
     };
   } catch {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -141,6 +141,7 @@ export interface PipelineConfig {
     model: string;
     baseUrl: string;
     computerUse: boolean;
+    apiKey?: string;
   };
 }
 

--- a/src/smart-interaction.ts
+++ b/src/smart-interaction.ts
@@ -29,6 +29,7 @@ import { CDPDriver } from './cdp-driver';
 import { UIDriver } from './ui-driver';
 import { AccessibilityBridge } from './accessibility';
 import { BrowserLayer } from './browser-layer';
+import { PROVIDERS } from './providers';
 import type { PipelineConfig, ProviderProfile } from './providers';
 import type { ClawdConfig, StepResult } from './types';
 
@@ -715,22 +716,10 @@ export class SmartInteractionLayer {
     const providerKey = this.config.ai.provider;
     const apiKey = this.config.ai.apiKey || '';
 
-    // For Anthropic, use Haiku; for others use their cheap model
-    const modelMap: Record<string, string> = {
-      anthropic: 'claude-haiku-3-5-20241022',
-      openai: 'gpt-4o-mini',
-      ollama: 'qwen2.5:7b',
-      kimi: 'moonshot-v1-8k',
-    };
-    const baseUrlMap: Record<string, string> = {
-      anthropic: 'https://api.anthropic.com/v1',
-      openai: 'https://api.openai.com/v1',
-      ollama: 'http://localhost:11434/v1',
-      kimi: 'https://api.moonshot.cn/v1',
-    };
-
-    const model = modelMap[providerKey] || 'gpt-4o-mini';
-    const baseUrl = baseUrlMap[providerKey] || 'https://api.openai.com/v1';
+    // Prefer provider registry defaults to stay universal as providers evolve
+    const providerProfile = PROVIDERS[providerKey] || PROVIDERS['openai'];
+    const model = providerProfile.textModel || this.config.ai.model || 'gpt-4o-mini';
+    const baseUrl = providerProfile.baseUrl || this.config.ai.baseUrl || 'https://api.openai.com/v1';
 
     // Build a minimal provider profile for the call
     const isAnthropic = providerKey === 'anthropic';


### PR DESCRIPTION
### Motivation

- Allow Computer Use (Anthropic-native tool) to be enabled with per-pipeline overrides (API key, model, baseUrl) so mixed-provider pipelines can use a different provider for Layer 3.
- Centralize provider defaults so text-model selection in smart interactions respects the `PROVIDERS` registry instead of hard-coded maps.

### Description

- Introduce `ComputerUseOverrides` and accept `pipelineOverrides` in `ComputerUseBrain` constructor, store overrides on the instance, and use them when determining support and making API calls.
- Update `ComputerUseBrain.isSupported` to consider pipeline overrides and change `callAPI` to use `baseUrl`, `apiKey`, and `model` from overrides (with fallbacks) and return a helpful error when no API key is available.
- Wire pipeline overrides through `Agent` initialization by computing `computerUseOverrides` from `pipelineConfig.layer3` and passing them into `ComputerUseBrain` when present.
- Update `loadPipelineConfig` to search the package directory for the config first, add `resolveProviderApiKey` to resolve provider-specific API keys, and populate `layer3.apiKey` when `computerUse` is enabled (preferring an explicit `pipeline.layer3.apiKey` or resolving via provider key).
- Extend `PipelineConfig` in `providers.ts` to include optional `layer3.apiKey` and change `SmartInteractionLayer` to prefer provider registry defaults from `PROVIDERS` for cheap text-model and base URL selection.

### Testing

- Ran the project test suite with `npm test`, which completed successfully.
- Ran a typecheck/build with `npm run build` to ensure the new types and constructor signature changes compile, which succeeded.
- Verified pipeline config loading with the updated `loadPipelineConfig()` path and `layer3` API key resolution by loading a sample pipeline config, which returned the expected `layer3.apiKey` and `computerUse` flags.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40f4325108327a0aeb7f00d213c84)