### PR TITLE
fix(mac): accept PascalCase args in invoke-element.jxa and focus-wind…

### DIFF
--- a/scripts/mac/focus-window.jxa
+++ b/scripts/mac/focus-window.jxa
@@ -34,11 +34,14 @@ function run(argv) {
         // Parse arguments from argv array
         var params = { title: null, processId: null };
         for (var i = 0; i < argv.length; i++) {
-            if (argv[i] === '-title' && i + 1 < argv.length) {
+            var a = argv[i];
+            var hasNext = i + 1 < argv.length;
+            if ((a === '-title' || a === '-Title') && hasNext) {
                 params.title = argv[++i];
-            } else if (argv[i] === '-processId' && i + 1 < argv.length) {
+            } else if ((a === '-processId' || a === '-ProcessId') && hasNext) {
                 params.processId = parseInt(argv[++i], 10);
             }
+            // -Restore has no direct macOS equivalent; silently ignore
         }
 
         // Validate parameters

--- a/scripts/mac/invoke-element.jxa
+++ b/scripts/mac/invoke-element.jxa
@@ -110,18 +110,35 @@ function run(argv) {
             processId: null,
             value: null
         };
+        // Windows ControlType → macOS AX role mapping (mirrors find-element.jxa)
+        var CONTROL_TYPE_MAP = {
+            'Button': 'button', 'Edit': 'text field', 'Document': 'web area',
+            'ComboBox': 'pop up button', 'CheckBox': 'checkbox',
+            'RadioButton': 'radio button', 'Hyperlink': 'link',
+            'MenuItem': 'menu item', 'Menu': 'menu', 'Tab': 'tab group',
+            'TabItem': 'radio button', 'ListItem': 'row', 'TreeItem': 'row',
+            'Slider': 'slider', 'ScrollBar': 'scroll bar',
+            'ToolBar': 'toolbar', 'StaticText': 'static text', 'Window': 'window'
+        };
+
         for (var i = 0; i < argv.length; i++) {
-            if (argv[i] === '-action' && i + 1 < argv.length) {
+            var a = argv[i];
+            var hasNext = i + 1 < argv.length;
+            if ((a === '-action' || a === '-Action') && hasNext) {
                 params.action = argv[++i];
-            } else if (argv[i] === '-name' && i + 1 < argv.length) {
+            } else if ((a === '-name' || a === '-Name') && hasNext) {
                 params.name = argv[++i];
-            } else if (argv[i] === '-role' && i + 1 < argv.length) {
+            } else if ((a === '-role') && hasNext) {
                 params.role = argv[++i];
-            } else if (argv[i] === '-processId' && i + 1 < argv.length) {
+            } else if (a === '-ControlType' && hasNext) {
+                var ct = argv[++i];
+                params.role = CONTROL_TYPE_MAP[ct] || ct.toLowerCase();
+            } else if ((a === '-processId' || a === '-ProcessId') && hasNext) {
                 params.processId = parseInt(argv[++i], 10);
-            } else if (argv[i] === '-value' && i + 1 < argv.length) {
+            } else if ((a === '-value' || a === '-Value') && hasNext) {
                 params.value = argv[++i];
             }
+            // -AutomationId and -Restore have no macOS equivalent; silently ignore
         }
 
         // Validate required parameters


### PR DESCRIPTION
…ow.jxa

accessibility.ts passes PascalCase flags (-Action, -Name, -ProcessId, -Value, -Title) when calling JXA scripts directly, but both scripts only matched lowercase equivalents, causing every element interaction and window focus call from the a11y layer to silently fail on macOS.

- invoke-element.jxa: add -Action/-Name/-ProcessId/-Value aliases and map -ControlType to the appropriate macOS AX role string
- focus-window.jxa: add -Title/-ProcessId aliases; silently ignore -Restore (no macOS equivalent)

The ui-driver.ts path (interact-element.sh → invoke-element.jxa) was already correct as the shell script normalises to lowercase before calling JXA.