### PR TITLE
Add cross-platform CI workflow (Windows/macOS/Linux) and update README

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,39 @@
+name: Cross-platform compatibility
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: ${{ matrix.os }} / Node ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [20.x, 22.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run test suite
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ clawdcursor doctor --provider together --api-key YOUR_KEY
 
 ## Compatibility (v0.6.0 Audit)
 
+Cross-platform checks are now automated in GitHub Actions on **Windows, macOS, and Linux** for both **Node 20** and **Node 22** (build + test).
+
 | OS | Status | Notes |
 |----|--------|-------|
 | Windows 10/11 | ✅ Full support | Native desktop automation via PowerShell + UI Automation scripts. |


### PR DESCRIPTION
### Motivation
- Automate cross-platform verification so build and test steps run on Windows, macOS, and Linux across supported Node versions to catch OS- or runtime-specific regressions early.

### Description
- Add `.github/workflows/cross-platform.yml` to run a matrix on `ubuntu-latest`, `windows-latest`, and `macos-latest` with Node `20.x` and `22.x`, performing `npm ci`, `npm run build`, and `npm test`, and update the README compatibility section to note the new automated checks.

### Testing
- Ran `npm run build` which completed successfully, ran `npm test` and the Vitest suite passed (`3 files`, `17 tests`), and ran `npm run lint` which failed due to existing lint violations unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a420a161f483279c688004bc22e838)