### PR TITLE
Restrict accessibility bridge to Windows/macOS and add Linux GPU detection in doctor

### DIFF
--- a/src/accessibility.ts
+++ b/src/accessibility.ts
@@ -17,6 +17,7 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 const PLATFORM = os.platform(); // 'win32' | 'darwin' | 'linux'
+const SUPPORTED_PLATFORMS = new Set(['win32', 'darwin']);
 const SCRIPTS_DIR = path.join(__dirname, '..', 'scripts');
 const MAC_SCRIPTS_DIR = path.join(SCRIPTS_DIR, 'mac');
 // macOS JXA scripts enumerate System Events which can be slow on some versions.
@@ -96,6 +97,14 @@ export class AccessibilityBridge {
    */
   async isShellAvailable(): Promise<boolean> {
     if (shellAvailable !== null) return shellAvailable;
+
+    if (!SUPPORTED_PLATFORMS.has(PLATFORM)) {
+      console.error(
+        `❌ Unsupported platform: ${PLATFORM}. Native accessibility automation currently supports Windows and macOS only.`
+      );
+      shellAvailable = false;
+      return false;
+    }
     
     try {
       if (PLATFORM === 'win32') {
@@ -109,10 +118,6 @@ export class AccessibilityBridge {
           ['-l', 'JavaScript', '-e', 'Application("System Events").processes.length; true'],
           { timeout: 5000 },
         );
-      } else {
-        console.error(`❌ Unsupported platform: ${PLATFORM}. Accessibility requires Windows or macOS.`);
-        shellAvailable = false;
-        return false;
       }
       shellAvailable = true;
       console.log(`✅ Accessibility bridge ready (${PLATFORM === 'win32' ? 'PowerShell' : 'osascript'})`);
@@ -489,12 +494,17 @@ export class AccessibilityBridge {
    */
   private runScript(scriptName: string, args: string[] = []): Promise<any> {
     return new Promise((resolve, reject) => {
+      if (!SUPPORTED_PLATFORMS.has(PLATFORM)) {
+        reject(new Error(`Accessibility scripts are not supported on platform: ${PLATFORM}`));
+        return;
+      }
+
       let command: string;
       let commandArgs: string[];
 
       // Resolve script name — accept both logical names and direct filenames
       const logicalName = scriptName.replace(/\.(ps1|jxa)$/, '');
-      const platformScripts = SCRIPT_MAP[PLATFORM] || SCRIPT_MAP['win32'];
+      const platformScripts = SCRIPT_MAP[PLATFORM];
       const resolvedScript = platformScripts[logicalName] || scriptName;
 
       if (PLATFORM === 'darwin') {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -795,6 +795,41 @@ async function detectGpuInfo(): Promise<string | null> {
     }
   }
 
+  if (process.platform === 'linux') {
+    // Prefer nvidia-smi for NVIDIA cards, then fall back to lspci parsing for generic adapters.
+    try {
+      const { stdout } = await execFileAsync('nvidia-smi', [
+        '--query-gpu=name,memory.total',
+        '--format=csv,noheader,nounits',
+      ]);
+      const lines = stdout
+        .split(/\r?\n/)
+        .map(l => l.trim())
+        .filter(Boolean);
+      if (lines.length > 0) {
+        return lines
+          .map(line => {
+            const parts = line.split(',').map(p => p.trim());
+            return parts.length >= 2 ? `${parts[0]} (${parts[1]} MB VRAM)` : line;
+          })
+          .join(' | ');
+      }
+    } catch { /* fallback to lspci */ }
+
+    try {
+      const { stdout } = await execFileAsync('lspci', []);
+      const lines = stdout
+        .split(/\r?\n/)
+        .map(l => l.trim())
+        .filter(Boolean)
+        .filter(line => /vga|3d|display/i.test(line))
+        .map(line => line.replace(/^[0-9a-fA-F:.]+\s+/, ''));
+      return lines.length > 0 ? lines.join(' | ') : null;
+    } catch {
+      return null;
+    }
+  }
+
   return null;
 }
 


### PR DESCRIPTION
### Motivation

- Prevent the accessibility bridge from attempting platform scripts on unsupported platforms (e.g. Linux) and provide clearer error messages. 
- Improve hardware reporting by adding GPU detection for Linux systems so the doctor can report GPU names and VRAM where available.

### Description

- Added a `SUPPORTED_PLATFORMS` set for `win32` and `darwin` and early-return logging in `isShellAvailable()` when the current platform is not supported. 
- Added an early rejection in `runScript()` for unsupported platforms and removed the fallback mapping to Windows scripts so only the platform's script map is used. 
- Added Linux GPU detection in `detectGpuInfo()` which prefers `nvidia-smi` output and falls back to parsing `lspci` for VGA/3D devices, returning formatted GPU names and memory when available. 
- Kept existing timeouts and error messaging for macOS/Windows shell probes and script execution behavior unchanged.

### Testing

- Ran TypeScript type-check with `tsc --noEmit` which completed successfully. 
- Executed the repository test suite with `npm test` and the automated tests passed. 
- Built and ran the CLI doctor flow on a macOS test machine to confirm no regressions in accessibility probing and on a Linux container to validate the new GPU detection path (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4596abb688327969cc981ff45f2ab)