### PR TITLE
fix(linux-arm64): postinstall patch for libnut on Linux ARM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clawd-cursor",
   "version": "0.5.1",
-  "description": "AI Desktop Agent — Native screen control via @nut-tree-fork/nut-js. Your AI sees the screen, moves the mouse, types, and completes tasks autonomously.",
+  "description": "AI Desktop Agent \u2014 Native screen control via @nut-tree-fork/nut-js. Your AI sees the screen, moves the mouse, types, and completes tasks autonomously.",
   "main": "dist/index.js",
   "bin": {
     "clawd-cursor": "dist/index.js"
@@ -13,7 +13,8 @@
     "stop": "node dist/index.js stop",
     "doctor": "node dist/index.js doctor",
     "lint": "eslint src/",
-    "test": "vitest"
+    "test": "vitest",
+    "postinstall": "bash scripts/arm-fix-libnut.sh"
   },
   "dependencies": {
     "@nut-tree-fork/nut-js": "^4.2.0",

--- a/scripts/arm-fix-libnut.sh
+++ b/scripts/arm-fix-libnut.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARCH="$(uname -m)"
+if [[ "$ARCH" != "aarch64" && "$ARCH" != "arm64" ]]; then
+  exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/node_modules/@nut-tree-fork/libnut-linux/build/Release/libnut.node"
+
+# Optional override: export LIBNUT_NODE_PATH=/abs/path/to/libnut.node
+CANDIDATES=(
+  "${LIBNUT_NODE_PATH:-}"
+  "$ROOT_DIR/libnut-core/build/Release/libnut.node"
+  "$ROOT_DIR/../libnut-core/build/Release/libnut.node"
+)
+
+SRC=""
+for candidate in "${CANDIDATES[@]}"; do
+  if [[ -n "$candidate" && -f "$candidate" ]]; then
+    SRC="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$SRC" ]]; then
+  echo "[arm-fix-libnut] ARM detected but no prebuilt libnut.node found." >&2
+  echo "[arm-fix-libnut] Checked: ROOT/libnut-core and ../libnut-core (or LIBNUT_NODE_PATH). Skipping patch." >&2
+  exit 0
+fi
+
+mkdir -p "$(dirname "$TARGET")"
+cp "$SRC" "$TARGET"
+
+if command -v file >/dev/null 2>&1; then
+  file "$TARGET" | grep -Eq 'aarch64|ARM aarch64' || {
+    echo "[arm-fix-libnut] copied file does not look like ARM64 binary: $TARGET" >&2
+    exit 1
+  }
+fi
+
+echo "[arm-fix-libnut] OK (ARM) -> $TARGET (source: $SRC)"


### PR DESCRIPTION
This PR adds a Linux ARM64-specific postinstall patch for libnut compatibility.

Scope (specific):
- Linux only
- ARM64/aarch64 only

What it changes:
- Adds a postinstall hook in package.json
- Adds scripts/arm-fix-libnut.sh
- No-op on non-ARM architectures
- Supports LIBNUT_NODE_PATH override + repo-relative fallback paths

Why:
- Ensures clawd-cursor works reliably on Linux ARM devices without affecting amd64/mac/windows flows.