### PR TITLE
feat: add Google Gemini provider support

### DIFF
--- a/src/ai-brain.ts
+++ b/src/ai-brain.ts
@@ -303,6 +303,7 @@ export class AIBrain {
     ollama: 'http://localhost:11434/v1',
     kimi: 'https://api.moonshot.cn/v1',
     openai: 'https://api.openai.com/v1',
+    gemini: 'https://generativelanguage.googleapis.com/v1beta/openai',
   };
 
   private async callLLM(systemPrompt: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,12 @@ program
       baseUrl: opts.baseUrl,
     });
 
+    // Read saved pipeline config for model name fallbacks
+    const { loadPipelineConfig } = await import('./doctor');
+    const savedPipeline = loadPipelineConfig();
+    const pipelineTextModel = savedPipeline?.layer2?.model || '';
+    const pipelineVisionModel = savedPipeline?.layer3?.model || '';
+
     const config: ClawdConfig = {
       ...DEFAULT_CONFIG,
       server: {
@@ -117,8 +123,8 @@ program
         textApiKey: resolvedApi.textApiKey,
         visionBaseUrl: resolvedApi.visionBaseUrl,
         visionApiKey: resolvedApi.visionApiKey,
-        model: opts.textModel || resolvedApi.textModel || opts.model || DEFAULT_CONFIG.ai.model,
-        visionModel: opts.visionModel || resolvedApi.visionModel || opts.model || DEFAULT_CONFIG.ai.visionModel,
+        model: opts.textModel || resolvedApi.textModel || opts.model || pipelineTextModel || DEFAULT_CONFIG.ai.model,
+        visionModel: opts.visionModel || resolvedApi.visionModel || opts.model || pipelineVisionModel || DEFAULT_CONFIG.ai.visionModel,
       },
       debug: opts.debug || false,
     };

--- a/src/openclaw-credentials.ts
+++ b/src/openclaw-credentials.ts
@@ -78,6 +78,7 @@ function inferProviderFromBaseUrl(baseUrl?: string): string | undefined {
   if (url.includes('groq')) return 'groq';
   if (url.includes('together')) return 'together';
   if (url.includes('deepseek')) return 'deepseek';
+  if (url.includes('generativelanguage') || url.includes('gemini')) return 'gemini';
   if (url.includes('nvidia') || url.includes('integrate.api')) return 'nvidia';
   if (url.includes('mistral')) return 'mistral';
   if (url.includes('fireworks')) return 'fireworks';
@@ -484,7 +485,7 @@ export function resolveApiConfig(opts?: {
   if (localApiKey || localBaseUrl || localTextModel || localVisionModel || opts?.provider) {
     return {
       apiKey: localApiKey,
-      provider: normalizeProvider(opts?.provider) || inferProviderFromBaseUrl(localBaseUrl),
+      provider: normalizeProvider(opts?.provider) || inferProviderFromBaseUrl(localBaseUrl) || localProvider,
       baseUrl: localBaseUrl,
       textModel: localTextModel,
       visionModel: localVisionModel,
@@ -498,7 +499,7 @@ export function resolveApiConfig(opts?: {
 
   return {
     apiKey: localApiKey,
-    provider: inferProviderFromBaseUrl(localBaseUrl),
+    provider: inferProviderFromBaseUrl(localBaseUrl) || localProvider,
     baseUrl: localBaseUrl,
     textModel: localTextModel,
     visionModel: localVisionModel,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -90,6 +90,15 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     openaiCompat: true,
     computerUse: false,
   },
+  gemini: {
+    name: 'Google Gemini',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    authHeader: (key) => ({ 'Authorization': `Bearer ${key}` }),
+    textModel: 'gemini-2.0-flash',
+    visionModel: 'gemini-2.0-flash',
+    openaiCompat: true,
+    computerUse: false,
+  },
   generic: {
     name: 'OpenAI-Compatible',
     baseUrl: '', // set from config
@@ -244,6 +253,7 @@ const PROVIDER_ENV_VARS: Record<string, string[]> = {
   groq: ['GROQ_API_KEY'],
   together: ['TOGETHER_API_KEY'],
   deepseek: ['DEEPSEEK_API_KEY'],
+  gemini: ['GEMINI_API_KEY'],
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds first-class Google Gemini support as an AI provider using Gemini's OpenAI-compatible endpoint.

## Changes

### src/providers.ts
- Added gemini entry to PROVIDERS map using the OpenAI-compatible base URL https://generativelanguage.googleapis.com/v1beta/openai
- Added gemini to PROVIDER_ENV_VARS so GEMINI_API_KEY env var is automatically detected

### src/openclaw-credentials.ts
- Added Gemini URL pattern to inferProviderFromBaseUrl() so the provider is correctly identified from the base URL
- Fixed esolveApiConfig() to propagate localProvider in both return paths (it was being read to find the right env key but then dropped from the returned object)

### src/ai-brain.ts
- Added gemini to AIBrain.BASE_URLS fallback map so the correct endpoint is used when aseUrl isn't explicitly set

### src/index.ts
- Fixed isionModel/model falling back to the pipeline config's layer3/layer2 model names when esolveApiConfig() returns no model - prevents an empty string being sent to the API causing silent failures in the vision loop

## Configuration

Set these env vars (or add to .env):

`.env
GEMINI_API_KEY=your_key_here
AI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai
AI_TEXT_MODEL=gemini-2.0-flash
AI_VISION_MODEL=gemini-2.0-flash
`

Or start with explicit flags:
`
clawdcursor start --provider gemini --api-key your_key_here
`

## Testing

Tested end-to-end on Windows with gemini-2.0-flash:
- YouTube search task (navigate + type + click) ?
- Gmail compose + send flow ?