### PR TITLE
docs: fix installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For orchestration best practices (how to avoid overlap and keep OpenClaw + Clawd
 
 ```bash
 # Install as OpenClaw skill
-openclaw skills install clawd-cursor
+clawhub install clawd-cursor
 ```
 
 ---


### PR DESCRIPTION
The installation command `openclaw skills install clawd-cursor` was reported as non-functional. The correct command is `clawhub install clawd-cursor`.