### PR TITLE
Linux fallbacks, cross-platform clipboard, and provider capability plumbing

### DIFF
--- a/src/__tests__/accessibility-linux.test.ts
+++ b/src/__tests__/accessibility-linux.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.fn();
+const psRunMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
+}));
+
+vi.mock('../ps-runner', () => ({
+  psRunner: {
+    start: vi.fn(),
+    run: psRunMock,
+  },
+}));
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: string) {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
+describe('AccessibilityBridge on Linux', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    psRunMock.mockReset();
+    setPlatform('linux');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('reports shell unavailable instead of attempting macOS osascript', async () => {
+    const { AccessibilityBridge } = await import('../accessibility');
+    const bridge = new AccessibilityBridge();
+    await expect(bridge.isShellAvailable()).resolves.toBe(false);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('returns empty windows/elements and non-throwing unsupported results', async () => {
+    const { AccessibilityBridge } = await import('../accessibility');
+    const bridge = new AccessibilityBridge();
+    await expect(bridge.getWindows()).resolves.toEqual([]);
+    await expect(bridge.findElement({ name: 'Save' })).resolves.toEqual([]);
+    await expect(bridge.invokeElement({ name: 'Save', action: 'click' })).resolves.toMatchObject({ success: false });
+  });
+
+  it('returns an explanatory screen context message', async () => {
+    const { AccessibilityBridge } = await import('../accessibility');
+    const bridge = new AccessibilityBridge();
+    await expect(bridge.getScreenContext()).resolves.toContain('Accessibility unavailable on Linux');
+  });
+});

--- a/src/__tests__/llm-client.test.ts
+++ b/src/__tests__/llm-client.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { callTextLLM, callVisionLLM } from '../llm-client';
+import type { PipelineConfig } from '../providers';
+
+const fetchMock = vi.fn();
+(globalThis as any).fetch = fetchMock;
+
+const baseProvider = {
+  name: 'Test Provider',
+  baseUrl: 'https://example.com/v1',
+  authHeader: (key: string) => ({ Authorization: `Bearer ${key}` }),
+  textModel: 'text-model',
+  visionModel: 'vision-model',
+  openaiCompat: true,
+  computerUse: false,
+};
+
+function makeConfig(overrides: Partial<PipelineConfig['provider']> = {}): PipelineConfig {
+  return {
+    provider: { ...baseProvider, ...overrides },
+    providerKey: 'test',
+    apiKey: 'test-key',
+    layer1: true,
+    layer2: { enabled: true, model: 'text-model', baseUrl: 'https://example.com/v1' },
+    layer3: { enabled: true, model: 'vision-model', baseUrl: 'https://example.com/v1', computerUse: false },
+  };
+}
+
+describe('llm-client provider capability handling', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }] }),
+    });
+  });
+
+  it('omits response_format for providers that disable JSON mode on text calls', async () => {
+    const config = makeConfig({ supportsJsonMode: false });
+    await callTextLLM(config, { user: 'hello', forceJson: true });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.response_format).toBeUndefined();
+  });
+
+  it('includes response_format for providers that allow JSON mode on vision calls', async () => {
+    const config = makeConfig({ supportsJsonMode: true });
+    await callVisionLLM(config, {
+      forceJson: true,
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.response_format).toEqual({ type: 'json_object' });
+  });
+});

--- a/src/accessibility.ts
+++ b/src/accessibility.ts
@@ -17,6 +17,9 @@ import { psRunner } from './ps-runner';
 
 const execFileAsync = promisify(execFile);
 const PLATFORM = os.platform();
+const IS_WIN = PLATFORM === 'win32';
+const IS_MAC = PLATFORM === 'darwin';
+const IS_LINUX = PLATFORM === 'linux';
 const SCRIPTS_DIR = path.join(__dirname, '..', 'scripts');
 const MAC_SCRIPTS_DIR = path.join(SCRIPTS_DIR, 'mac');
 
@@ -27,6 +30,11 @@ const MAX_DEPTH = 8; // raised to 8 — Electron/WebView2 apps (Outlook olk) nes
 
 /** Cached shell availability (macOS only — Windows uses psRunner) */
 let macShellAvailable: boolean | null = null;
+
+function unsupportedLinuxResult<T>(fallback: T, feature: string): T {
+  console.debug(`[A11y] Linux accessibility feature not yet implemented: ${feature}`);
+  return fallback;
+}
 
 export interface UIElement {
   name: string;
@@ -85,7 +93,8 @@ export class AccessibilityBridge {
    * macOS:   checks osascript + Accessibility permissions.
    */
   async isShellAvailable(): Promise<boolean> {
-    if (PLATFORM === 'win32') return true; // PSRunner handles availability
+    if (IS_WIN) return true; // PSRunner handles availability
+    if (IS_LINUX) return false; // AT-SPI bridge not yet implemented
 
     if (macShellAvailable !== null) return macShellAvailable;
 
@@ -115,7 +124,7 @@ export class AccessibilityBridge {
 
   /** Start the PSRunner bridge early so the 800ms assembly load happens in background. */
   async warmup(): Promise<void> {
-    if (PLATFORM === 'win32') {
+    if (IS_WIN) {
       psRunner.start().catch(() => {}); // fire-and-forget — errors surface on first actual call
     }
   }
@@ -171,13 +180,16 @@ export class AccessibilityBridge {
     }
 
     let windows: WindowInfo[];
-    if (PLATFORM === 'win32') {
+    if (IS_WIN) {
       const result = await this.winCmd({ cmd: 'get-screen-context', maxDepth: 0 }) as any;
       windows = result.windows ?? [];
       // Update screen context cache timestamp so we don't double-fetch
       this.windowCache = { windows, timestamp: Date.now() };
-    } else {
+    } else if (IS_MAC) {
       windows = await this.runMacScript('get-windows.jxa');
+      this.windowCache = { windows, timestamp: Date.now() };
+    } else {
+      windows = unsupportedLinuxResult([], 'getWindows');
       this.windowCache = { windows, timestamp: Date.now() };
     }
     return windows;
@@ -189,7 +201,7 @@ export class AccessibilityBridge {
     controlType?: string;
     processId?: number;
   }): Promise<UIElement[]> {
-    if (PLATFORM === 'win32') {
+    if (IS_WIN) {
       const result = await this.winCmd({
         cmd: 'find-element',
         ...(opts.name        && { name:        opts.name }),
@@ -198,7 +210,8 @@ export class AccessibilityBridge {
         ...(opts.processId    && { processId:    opts.processId }),
       }) as any;
       return Array.isArray(result) ? result : [];
-    } else {
+    }
+    if (IS_MAC) {
       const args: string[] = [];
       if (opts.name)         args.push('-Name', opts.name);
       if (opts.automationId) args.push('-AutomationId', opts.automationId);
@@ -206,6 +219,7 @@ export class AccessibilityBridge {
       if (opts.processId)    args.push('-ProcessId', String(opts.processId));
       return this.runMacScript('find-element.jxa', args);
     }
+    return unsupportedLinuxResult([], 'findElement');
   }
 
   async invokeElement(opts: {
@@ -240,7 +254,7 @@ export class AccessibilityBridge {
       }
     }
 
-    if (PLATFORM === 'win32') {
+    if (IS_WIN) {
       const result = await this.winCmd({
         cmd: 'invoke-element',
         processId,
@@ -251,7 +265,8 @@ export class AccessibilityBridge {
         ...(opts.value        && { value:        opts.value }),
       }) as any;
       return result;
-    } else {
+    }
+    if (IS_MAC) {
       const args: string[] = ['-Action', opts.action, '-ProcessId', String(processId)];
       if (opts.name)         args.push('-Name', opts.name);
       if (opts.automationId) args.push('-AutomationId', opts.automationId);
@@ -259,6 +274,7 @@ export class AccessibilityBridge {
       if (opts.value)        args.push('-Value', opts.value);
       return this.runMacScript('invoke-element.jxa', args);
     }
+    return unsupportedLinuxResult({ success: false, error: 'Linux accessibility bridge not implemented' }, 'invokeElement');
   }
 
   async focusWindow(
@@ -267,19 +283,21 @@ export class AccessibilityBridge {
   ): Promise<{ success: boolean; title?: string; processId?: number; error?: string }> {
     try {
       let result: any;
-      if (PLATFORM === 'win32') {
+      if (IS_WIN) {
         result = await this.winCmd({
           cmd:     'focus-window',
           restore: true,
           ...(title     && { title }),
           ...(processId && { processId }),
         });
-      } else {
+      } else if (IS_MAC) {
         const args: string[] = [];
         if (title)     args.push('-Title', title);
         if (processId) args.push('-ProcessId', String(processId));
         args.push('-Restore');
         result = await this.runMacScript('focus-window.jxa', args);
+      } else {
+        result = unsupportedLinuxResult({ success: false, error: 'Linux accessibility bridge not implemented' }, 'focusWindow');
       }
       this.invalidateCache();
       return result;
@@ -291,10 +309,12 @@ export class AccessibilityBridge {
   async getActiveWindow(): Promise<WindowInfo | null> {
     try {
       let fg: any;
-      if (PLATFORM === 'win32') {
+      if (IS_WIN) {
         fg = await this.winCmd({ cmd: 'get-foreground-window' });
-      } else {
+      } else if (IS_MAC) {
         fg = await this.runMacScript('get-foreground-window.jxa');
+      } else {
+        return null;
       }
       if (!fg?.success) return null;
 
@@ -332,7 +352,7 @@ export class AccessibilityBridge {
   }
 
   async getFocusedElement(): Promise<FocusedElementInfo | null> {
-    if (PLATFORM === 'win32') {
+    if (IS_WIN) {
       try {
         const result = await this.winCmd({ cmd: 'get-focused-element' }) as any;
         if (!result?.success) return null;
@@ -350,7 +370,7 @@ export class AccessibilityBridge {
         return null;
       }
     }
-    if (PLATFORM === 'darwin') {
+    if (IS_MAC) {
       try {
         const script = path.join(MAC_SCRIPTS_DIR, 'get-focused-element.jxa');
         const { stdout } = await execFileAsync('osascript', ['-l', 'JavaScript', script], {
@@ -384,16 +404,21 @@ export class AccessibilityBridge {
    */
   async readClipboard(): Promise<string> {
     try {
-      if (PLATFORM === 'win32') {
+      if (IS_WIN) {
         const { stdout } = await execFileAsync('powershell.exe', [
           '-NoProfile', '-Command', 'Get-Clipboard',
         ], { timeout: 2000 });
         return stdout?.trim() ?? '';
-      } else {
-        // macOS: pbpaste
+      }
+      if (IS_MAC) {
         const { stdout } = await execFileAsync('pbpaste', [], { timeout: 2000 });
         return stdout?.trim() ?? '';
       }
+      if (IS_LINUX) {
+        const { stdout } = await execFileAsync('sh', ['-lc', 'if command -v wl-paste >/dev/null 2>&1; then wl-paste --no-newline; elif command -v xclip >/dev/null 2>&1; then xclip -selection clipboard -o; elif command -v xsel >/dev/null 2>&1; then xsel --clipboard --output; fi'], { timeout: 2000 });
+        return stdout?.trim() ?? '';
+      }
+      return '';
     } catch {
       return '';
     }
@@ -405,7 +430,7 @@ export class AccessibilityBridge {
    */
   async writeClipboard(text: string): Promise<void> {
     try {
-      if (PLATFORM === 'win32') {
+      if (IS_WIN) {
         // Use -EncodedCommand with Base64-encoded UTF-16LE to safely handle
         // all characters (quotes, newlines, special chars) without escaping issues.
         const utf16 = Buffer.from(
@@ -415,10 +440,18 @@ export class AccessibilityBridge {
         await execFileAsync('powershell.exe', [
           '-NoProfile', '-EncodedCommand', utf16.toString('base64'),
         ], { timeout: 2000 });
-      } else {
+      } else if (IS_MAC) {
         // macOS: pipe to pbcopy via shell
         await new Promise<void>((resolve, reject) => {
           const proc = execFile('pbcopy', [], { timeout: 2000 }, (err) => {
+            if (err) reject(err); else resolve();
+          });
+          proc.stdin?.write(text);
+          proc.stdin?.end();
+        });
+      } else if (IS_LINUX) {
+        await new Promise<void>((resolve, reject) => {
+          const proc = execFile('sh', ['-lc', 'if command -v wl-copy >/dev/null 2>&1; then wl-copy; elif command -v xclip >/dev/null 2>&1; then xclip -selection clipboard; elif command -v xsel >/dev/null 2>&1; then xsel --clipboard --input; else exit 1; fi'], { timeout: 2000 }, (err) => {
             if (err) reject(err); else resolve();
           });
           proc.stdin?.write(text);
@@ -443,10 +476,9 @@ export class AccessibilityBridge {
     }
 
     let context = '';
-    let treeError = false;
 
     try {
-      if (PLATFORM === 'win32') {
+      if (IS_WIN) {
         const combined = await this.winCmd({
           cmd:              'get-screen-context',
           maxDepth:         MAX_DEPTH,
@@ -470,7 +502,7 @@ export class AccessibilityBridge {
             '  ',
           );
         }
-      } else {
+      } else if (IS_MAC) {
         // macOS — separate script calls
         const windows = await this.getWindows();
         context += 'WINDOWS:\n';
@@ -490,14 +522,15 @@ export class AccessibilityBridge {
             context += this.formatTree(tree, '  ');
           } catch { /* skip */ }
         }
+      } else {
+        context += '(Accessibility unavailable on Linux — browser CDP and OCR remain available)';
       }
     } catch (err) {
       context += `\n[A11y tree unavailable: ${err}]\n`;
-      treeError = true;
     }
 
     // Always append focused element — even when the tree query failed, focus info is critical
-    if (PLATFORM === 'win32') {
+    if (IS_WIN) {
       try {
         const focused = await this.getFocusedElement();
         if (focused) {

--- a/src/browser-layer.ts
+++ b/src/browser-layer.ts
@@ -238,6 +238,8 @@ export class BrowserLayer {
         `], { timeout: 5000 });
       } else if (process.platform === 'darwin') {
         await execFileAsync('osascript', ['-e', 'tell application "Google Chrome" to activate'], { timeout: 5000 });
+      } else if (process.platform === 'linux') {
+        await execFileAsync('sh', ['-lc', `if command -v wmctrl >/dev/null 2>&1; then wmctrl -xa chrome || wmctrl -xa Chromium || wmctrl -xa firefox; elif command -v xdotool >/dev/null 2>&1; then xdotool search --onlyvisible --class 'chrome|chromium|firefox' windowactivate %@; else exit 1; fi`], { timeout: 5000 });
       }
       console.log(`   🪟 Brought browser to foreground`);
     } catch (e: any) {

--- a/src/generic-computer-use.ts
+++ b/src/generic-computer-use.ts
@@ -23,7 +23,7 @@ import { SafetyLayer, } from './safety';
 import { SafetyTier } from './types';
 import { normalizeKeyCombo } from './keys';
 import type { ClawdConfig, StepResult } from './types';
-import type { PipelineConfig } from './providers';
+import { supportsOpenAiToolCalls, type PipelineConfig } from './providers';
 import type { TaskLogger } from './task-logger';
 import type { TaskVerifier } from './verifiers';
 
@@ -105,6 +105,8 @@ export function isGenericComputerUseSupported(
 ): boolean {
   // Anthropic has its own native CU — don't use generic for it
   if (config.ai.provider === 'anthropic' && !config.ai.visionBaseUrl) return false;
+  if (pipelineConfig?.provider && !pipelineConfig.provider.openaiCompat) return false;
+  if (pipelineConfig?.provider && !supportsOpenAiToolCalls(pipelineConfig.provider)) return false;
 
   // Need a vision model
   const visionModel = pipelineConfig?.layer3?.model || config.ai.visionModel;
@@ -319,6 +321,7 @@ export class GenericComputerUse {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${visionKey}`,
+          ...(this.pipelineConfig?.provider?.extraHeaders || {}),
         },
         body: JSON.stringify({
           model: visionModel,

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -13,7 +13,7 @@
  * and the client auto-converts to the correct format for the target provider.
  */
 
-import type { PipelineConfig } from './providers';
+import { supportsOpenAiJsonMode, type PipelineConfig } from './providers';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // LLM Error Classes
@@ -76,7 +76,7 @@ export async function callTextLLM(
   const isAnthropic = !config.provider.openaiCompat
     && !baseUrl.includes('localhost')
     && !baseUrl.includes('11434');
-  const authHeaders = config.provider.authHeader(apiKey);
+  const authHeaders = { ...config.provider.authHeader(apiKey), ...(config.provider.extraHeaders || {}) };
 
   return _callText({
     baseUrl,
@@ -84,6 +84,7 @@ export async function callTextLLM(
     apiKey,
     isAnthropic,
     authHeaders,
+    providerProfile: config.provider,
     ...options,
   });
 }
@@ -112,6 +113,7 @@ interface InternalCallOptions extends TextLLMOptions {
   apiKey: string;
   isAnthropic: boolean;
   authHeaders: Record<string, string>;
+  providerProfile?: PipelineConfig['provider'];
 }
 
 async function _callText(opts: InternalCallOptions): Promise<string> {
@@ -136,9 +138,10 @@ async function _callText(opts: InternalCallOptions): Promise<string> {
         console.log(`   🔗 LLM text call (attempt ${attempt + 1}): model=${model}`);
       }
 
+      const canUseJsonMode = supportsOpenAiJsonMode(opts.providerProfile);
       const result = isAnthropic
         ? await _callAnthropic({ baseUrl, model, authHeaders, system, user, rawMessages, forceJson, maxTokens, timeoutMs })
-        : await _callOpenAI({ baseUrl, model, authHeaders, system, user, rawMessages, forceJson, maxTokens, timeoutMs });
+        : await _callOpenAI({ baseUrl, model, authHeaders, system, user, rawMessages, forceJson, maxTokens, timeoutMs, canUseJsonMode });
 
       return result;
     } catch (err) {
@@ -171,6 +174,7 @@ async function _callOpenAI(p: {
   forceJson: boolean;
   maxTokens: number;
   timeoutMs?: number;
+  canUseJsonMode?: boolean;
 }): Promise<string> {
   // Build messages: either from rawMessages or from system+user
   let messages: Array<{ role: string; content: string }>;
@@ -192,7 +196,7 @@ async function _callOpenAI(p: {
   if (!p.model.startsWith('kimi-k2')) {
     body.temperature = 0;
   }
-  if (p.forceJson) {
+  if (p.forceJson && p.canUseJsonMode !== false) {
     body.response_format = { type: 'json_object' };
   }
 
@@ -322,6 +326,7 @@ export interface DirectVisionLLMOptions extends VisionLLMOptions {
   model: string;
   apiKey: string;
   isAnthropic: boolean;
+  providerProfile?: PipelineConfig['provider'];
 }
 
 /**
@@ -381,7 +386,7 @@ export async function callVisionLLM(
     && !baseUrl.includes('localhost')
     && !baseUrl.includes('11434');
 
-  return callVisionLLMDirect({ ...options, baseUrl, model, apiKey, isAnthropic });
+  return callVisionLLMDirect({ ...options, baseUrl, model, apiKey, isAnthropic, providerProfile: config.provider });
 }
 
 /**
@@ -427,7 +432,7 @@ async function _callVisionOpenAI(p: DirectVisionLLMOptions & { authHeaders: Reco
   if (!p.model.startsWith('kimi-k2')) {
     body.temperature = 0;
   }
-  if (p.forceJson) {
+  if (p.forceJson && supportsOpenAiJsonMode(p.providerProfile)) {
     body.response_format = { type: 'json_object' };
   }
 

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -21,6 +21,10 @@ export interface ProviderProfile {
   extraHeaders?: Record<string, string>;
   /** Whether this provider supports Computer Use tool */
   computerUse: boolean;
+  /** Whether OpenAI-style JSON response_format is known to work reliably */
+  supportsJsonMode?: boolean;
+  /** Whether OpenAI-style tool calls are known to work reliably */
+  supportsToolCalls?: boolean;
 }
 
 export const PROVIDERS: Record<string, ProviderProfile> = {
@@ -35,6 +39,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'claude-sonnet-4-20250514',
     openaiCompat: false,
     computerUse: true,
+    supportsJsonMode: false,
+    supportsToolCalls: false,
   },
   openai: {
     name: 'OpenAI',
@@ -44,15 +50,19 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'gpt-4o',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   ollama: {
     name: 'Ollama (Local)',
     baseUrl: 'http://localhost:11434/v1',
     authHeader: () => ({}),
-    textModel: '',  // auto-detected from available models by doctor
-    visionModel: '', // auto-detected from available models by doctor
+    textModel: '',
+    visionModel: '',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   kimi: {
     name: 'Kimi (Moonshot)',
@@ -62,6 +72,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'kimi-k2.5',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   groq: {
     name: 'Groq',
@@ -71,6 +83,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'llama-3.2-90b-vision-preview',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   together: {
     name: 'Together AI',
@@ -80,6 +94,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   deepseek: {
     name: 'DeepSeek',
@@ -89,6 +105,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'deepseek-chat',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   gemini: {
     name: 'Google Gemini',
@@ -98,6 +116,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'gemini-2.0-flash',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   mistral: {
     name: 'Mistral AI',
@@ -107,6 +127,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'pixtral-large-latest',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   xai: {
     name: 'xAI (Grok)',
@@ -116,6 +138,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'grok-2-vision-1212',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   alibaba: {
     name: 'Alibaba (Qwen/DashScope)',
@@ -125,6 +149,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'qwen-vl-max',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   fireworks: {
     name: 'Fireworks AI',
@@ -134,6 +160,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'accounts/fireworks/models/llama-v3p2-90b-vision-instruct',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
   cohere: {
     name: 'Cohere',
@@ -143,6 +171,8 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'command-r-plus',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: false,
+    supportsToolCalls: false,
   },
   perplexity: {
     name: 'Perplexity',
@@ -152,15 +182,19 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     visionModel: 'llama-3.1-sonar-large-128k-online',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: false,
+    supportsToolCalls: false,
   },
   generic: {
     name: 'OpenAI-Compatible',
-    baseUrl: '', // set from config
+    baseUrl: '',
     authHeader: (key) => ({ 'Authorization': `Bearer ${key}` }),
-    textModel: '', // set from config
-    visionModel: '', // set from config  
+    textModel: '',
+    visionModel: '',
     openaiCompat: true,
     computerUse: false,
+    supportsJsonMode: true,
+    supportsToolCalls: true,
   },
 };
 
@@ -246,6 +280,15 @@ export function buildPipeline(
       computerUse: provider.computerUse,
     },
   };
+}
+
+
+export function supportsOpenAiJsonMode(provider: ProviderProfile | undefined): boolean {
+  return provider?.supportsJsonMode !== false;
+}
+
+export function supportsOpenAiToolCalls(provider: ProviderProfile | undefined): boolean {
+  return provider?.supportsToolCalls !== false;
 }
 
 // ─── Multi-Provider Scanning ──────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Provide sane behavior on Linux where accessibility (AT-SPI) is not yet implemented by returning clear fallbacks instead of attempting macOS/Windows calls.
- Make OpenAI-compatible provider behavior explicit so JSON `response_format` and tool calls are only used when supported by the provider profile. 
- Improve cross-platform clipboard and browser activation support for Linux and allow provider-level extra headers to flow through LLM calls.

### Description
- Add platform booleans (`IS_WIN`, `IS_MAC`, `IS_LINUX`) and `unsupportedLinuxResult` helper in `src/accessibility.ts`, implement Linux fallbacks for `isShellAvailable`, `getWindows`, `findElement`, `invokeElement`, `focusWindow`, `getActiveWindow`, and `getFocusedElement`, and update `getScreenContext` to emit an explanatory Linux message.
- Implement cross-platform clipboard read/write on Linux using `wl-paste`/`xclip`/`xsel` and `wl-copy`/`xclip`/`xsel` shells in `src/accessibility.ts`.
- Add a Linux branch to `bringBrowserToFront` in `src/browser-layer.ts` that uses `wmctrl` or `xdotool` when available.
- Extend `ProviderProfile` in `src/providers.ts` with `supportsJsonMode` and `supportsToolCalls`, populate flags for existing providers, and add helper functions `supportsOpenAiJsonMode` and `supportsOpenAiToolCalls`.
- Propagate provider profile and `extraHeaders` through LLM call paths: merge `extraHeaders` into `authHeaders` in `callTextLLM`, pass `providerProfile` into internal calls, and respect provider `supportsJsonMode` when setting `response_format` in both text and vision flows in `src/llm-client.ts` and `src/generic-computer-use.ts`.
- Require OpenAI-compat and provider tool-call support for generic computer use in `src/generic-computer-use.ts` by checking `provider.openaiCompat` and `supportsOpenAiToolCalls`.
- Add unit tests: `src/__tests__/accessibility-linux.test.ts` to validate Linux accessibility fallbacks and `src/__tests__/llm-client.test.ts` to verify `response_format` behavior based on provider capabilities.

### Testing
- Added `vitest` unit tests `accessibility-linux.test.ts` and `llm-client.test.ts` exercising Linux a11y fallbacks and provider JSON mode handling, and ran the test suite with `vitest`; the new tests passed.
- Ran the LLM client unit assertions that verify `response_format` presence/absence for providers with `supportsJsonMode` toggled and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd067dc81c8327bb5e4623684df0e4)