### PR TITLE
Infer vision provider from layer baseUrl and improve cross-platform desktop/orchestration behavior

### DIFF
--- a/src/__tests__/llm-client.test.ts
+++ b/src/__tests__/llm-client.test.ts
@@ -51,4 +51,24 @@ describe('llm-client provider capability handling', () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.response_format).toEqual({ type: 'json_object' });
   });
+
+  it('uses active vision layer baseUrl to infer API format in mixed-provider pipelines', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: [{ text: 'ok' }] }),
+    });
+
+    const config = makeConfig({
+      openaiCompat: true, // main provider openai-compat
+    });
+    config.providerKey = 'openai';
+    config.layer3.baseUrl = 'https://api.anthropic.com/v1'; // vision layer is Anthropic
+
+    await callVisionLLM(config, {
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'describe' }] }],
+    });
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.anthropic.com/v1/messages');
+  });
 });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -303,7 +303,7 @@ export class Agent {
 
     // Minimize the terminal/console window running this agent so it never
     // appears in screenshots and the vision LLM can't accidentally close it.
-    if (!IS_MAC) {
+    if (process.platform === 'win32') {
       try {
         await execFileAsync('powershell.exe', ['-Command',
           `Add-Type -TypeDefinition @"
@@ -1673,4 +1673,3 @@ function tierEmoji(tier: SafetyTier): string {
     case SafetyTier.Confirm: return '🔴';
   }
 }
-

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -392,11 +392,14 @@ export async function callVisionLLM(
   const model = layer.model;
   // Use layer-specific API key if available (mixed pipelines use different keys per layer)
   const apiKey = (config.layer3.enabled ? config.layer3.apiKey : undefined) || config.apiKey || '';
-  const isAnthropic = !config.provider.openaiCompat
+  // Determine protocol from active layer endpoint (mixed-provider pipelines are supported).
+  const layerProviderKey = inferProviderFromBaseUrl(baseUrl) || config.providerKey;
+  const layerProvider = PROVIDERS[layerProviderKey] || config.provider;
+  const isAnthropic = !layerProvider.openaiCompat
     && !baseUrl.includes('localhost')
     && !baseUrl.includes('11434');
 
-  return callVisionLLMDirect({ ...options, baseUrl, model, apiKey, isAnthropic, providerProfile: config.provider });
+  return callVisionLLMDirect({ ...options, baseUrl, model, apiKey, isAnthropic, providerProfile: layerProvider });
 }
 
 /**

--- a/src/tools/desktop.ts
+++ b/src/tools/desktop.ts
@@ -6,10 +6,12 @@
  * The server auto-scales to Windows LOGICAL coordinates via mouseScaleFactor.
  */
 
+import * as os from 'os';
 import type { ToolDefinition } from './types';
 
 /** Dangerous key combos that are blocked */
 const BLOCKED_KEYS = ['alt+f4', 'ctrl+alt+delete', 'ctrl+alt+del'];
+const IS_MAC = os.platform() === 'darwin';
 
 export function getDesktopTools(): ToolDefinition[] {
   return [
@@ -214,7 +216,8 @@ export function getDesktopTools(): ToolDefinition[] {
         const activeInfo = active ? `[${active.processName}] "${active.title}"` : '(unknown)';
         await ctx.a11y.writeClipboard(text);
         await new Promise(r => setTimeout(r, 50));
-        await ctx.desktop.keyPress('ctrl+v');
+        // Paste combo is platform-specific
+        await ctx.desktop.keyPress(IS_MAC ? 'super+v' : 'ctrl+v');
         await new Promise(r => setTimeout(r, 100));
         ctx.a11y.invalidateCache();
         return { text: `Typed ${text.length} chars into ${activeInfo}` };

--- a/src/tools/orchestration.ts
+++ b/src/tools/orchestration.ts
@@ -49,6 +49,15 @@ function formatAgentHttpError(status: number, body: string, statusText: string):
   }
 }
 
+async function commandExists(cmd: string): Promise<boolean> {
+  try {
+    await execFileAsync('which', [cmd], { timeout: 2000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function getOrchestrationTools(): ToolDefinition[] {
   return [
     {
@@ -114,7 +123,14 @@ export function getOrchestrationTools(): ToolDefinition[] {
           } else if (process.platform === 'darwin') {
             await execFileAsync('open', ['-a', name], { timeout: 10000 });
           } else {
-            await execFileAsync(name, [], { timeout: 10000 });
+            // Linux: prefer desktop-aware launchers, then direct executable.
+            if (await commandExists('gtk-launch')) {
+              await execFileAsync('gtk-launch', [name], { timeout: 10000 });
+            } else if (await commandExists('xdg-open')) {
+              await execFileAsync('xdg-open', [name], { timeout: 10000 });
+            } else {
+              await execFileAsync(name, [], { timeout: 10000 });
+            }
           }
           await new Promise(r => setTimeout(r, 2000));
           ctx.a11y.invalidateCache();
@@ -155,9 +171,20 @@ export function getOrchestrationTools(): ToolDefinition[] {
               `--remote-debugging-port=${DEFAULT_CDP_PORT}`, `--user-data-dir=${userDataDir}`, '--no-first-run', url
             ], { timeout: 10000 });
           } else {
-            await execFileAsync('google-chrome', [
-              `--remote-debugging-port=${DEFAULT_CDP_PORT}`, `--user-data-dir=${userDataDir}`, '--no-first-run', url
-            ], { timeout: 10000 });
+            // Linux: try common browser binaries in order.
+            const browserCandidates = ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser', 'microsoft-edge'];
+            let launched = false;
+            for (const browserCmd of browserCandidates) {
+              if (!(await commandExists(browserCmd))) continue;
+              await execFileAsync(browserCmd, [
+                `--remote-debugging-port=${DEFAULT_CDP_PORT}`, `--user-data-dir=${userDataDir}`, '--no-first-run', url,
+              ], { timeout: 10000 });
+              launched = true;
+              break;
+            }
+            if (!launched) {
+              throw new Error('No supported browser binary found (tried: google-chrome, chromium, microsoft-edge)');
+            }
           }
           await new Promise(r => setTimeout(r, 3000));
           ctx.a11y.invalidateCache();


### PR DESCRIPTION
### Motivation

- Support mixed-provider pipelines by using the active vision layer endpoint to determine the API/protocol, and make desktop tooling and orchestration more robust across Windows, macOS and Linux.

### Description

- Infer the active vision layer provider from the layer `baseUrl` in `callVisionLLM` and select the correct provider profile and `openaiCompat` flag before delegating to `callVisionLLMDirect` by using `inferProviderFromBaseUrl` and `PROVIDERS`.
- Add a new unit test in `src/__tests__/llm-client.test.ts` to verify that the active vision layer `baseUrl` is used to pick the correct Anthropic/OpenAI endpoint in mixed-provider pipelines.
- Improve platform handling in desktop tools by importing `os`, introducing `IS_MAC`, and using a platform-specific paste combo (`super+v` on macOS, `ctrl+v` elsewhere) in `type_text` handler in `src/tools/desktop.ts`.
- Restrict the console-minimization branch in `Agent.connect` to Windows by checking `process.platform === 'win32'` in `src/agent.ts`.
- Add `commandExists` helper and enhance Linux launch behavior in `src/tools/orchestration.ts` to prefer `gtk-launch`/`xdg-open` for `open_app` and to try multiple browser binaries for `navigate_browser`, failing with a clear error if none are found.

### Testing

- Ran the unit test suite including `src/__tests__/llm-client.test.ts` with the new mixed-provider test, and the tests completed successfully.
- Ran automated build/type checks (via the project test command) and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1ff36f2588327b5e79c6cf50c9fc0)