### PR TITLE
Introduce ClawdCursorHost (host IPC) and macOS native helper enhancements

### DIFF
--- a/native/ClawdCursor.app/Contents/Info.plist
+++ b/native/ClawdCursor.app/Contents/Info.plist
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>
-    <string>com.clawdcursor.helper</string>
+    <string>com.clawdcursor.app</string>
     <key>CFBundleExecutable</key>
-    <string>clawdcursor-helper</string>
+    <string>ClawdCursorHost</string>
     <key>CFBundleName</key>
-    <string>ClawdCursor Helper</string>
+    <string>ClawdCursor</string>
     <key>CFBundleDisplayName</key>
-    <string>ClawdCursor Helper</string>
+    <string>ClawdCursor</string>
     <key>CFBundleVersion</key>
     <string>1.0.0</string>
     <key>CFBundleShortVersionString</key>

--- a/native/Package.swift
+++ b/native/Package.swift
@@ -7,12 +7,18 @@ let package = Package(
         .macOS(.v12)
     ],
     products: [
+        .executable(name: "ClawdCursorHost", targets: ["ClawdCursorHost"]),
         .executable(name: "clawdcursor-helper", targets: ["ClawdCursorHelper"]),
         .executable(name: "screenshot-helper", targets: ["ScreenshotHelper"]),
         .executable(name: "permission-check", targets: ["PermissionCheck"])
     ],
     dependencies: [],
     targets: [
+        .executableTarget(
+            name: "ClawdCursorHost",
+            dependencies: [],
+            path: "Sources/ClawdCursorHost"
+        ),
         .executableTarget(
             name: "ClawdCursorHelper",
             dependencies: [],

--- a/native/README.md
+++ b/native/README.md
@@ -1,6 +1,6 @@
 # ClawdCursor Native Helper (macOS)
 
-Native Swift helper for macOS that consolidates all TCC (Transparency, Consent, and Control) permissions under a single app identity.
+Native Swift host app for macOS that consolidates all TCC (Transparency, Consent, and Control) permissions under a single app identity.
 
 ## Why?
 
@@ -46,8 +46,17 @@ Use `--prompt` to trigger the system permission dialog:
 ./ClawdCursor.app/Contents/MacOS/permission-check --prompt
 ```
 
+### `ClawdCursorHost` (app executable)
+The app process now owns IPC over localhost (`127.0.0.1:3848` by default):
+
+- `GET /health` host liveness
+- `GET /status` permission status
+- `POST /rpc` JSON-RPC proxy for desktop methods
+
+The CLI checks/launches this app on `clawdcursor start`.
+
 ### `clawdcursor-helper`
-Main helper daemon. Communicates via JSON-RPC over stdin/stdout:
+Worker binary used by the host app for JSON-RPC methods:
 
 ```json
 {"id":1,"method":"checkPermissions"}
@@ -79,9 +88,10 @@ Isolated subprocess for screen capture. Prevents ReplayKit CPU spin after captur
 ┌─────────────────────────────────────────────────────────────┐
 │ Node.js (clawdcursor CLI)                                   │
 │   └── NativeHelper class (native-helper.ts)                 │
-│         └── spawn + JSON-RPC over stdio                     │
+│         └── localhost IPC (127.0.0.1:3848)                  │
 ├─────────────────────────────────────────────────────────────┤
 │ ClawdCursor.app/Contents/MacOS/                             │
+│   ├── ClawdCursorHost    (bundle identity + IPC endpoint)   │
 │   ├── clawdcursor-helper  (AX traversal, input, app ctrl)   │
 │   ├── screenshot-helper   (isolated screen capture)         │
 │   └── permission-check    (quick permission status)         │

--- a/native/Sources/ClawdCursorHelper/main.swift
+++ b/native/Sources/ClawdCursorHelper/main.swift
@@ -14,6 +14,8 @@ import Foundation
 import ApplicationServices
 import CoreGraphics
 import AppKit
+import ImageIO
+import UniformTypeIdentifiers
 
 // MARK: - JSON-RPC Types
 
@@ -144,10 +146,16 @@ class ClawdCursorHelper {
             response = traverseAccessibilityTree(id: request.id, params: request.params)
         case "click":
             response = click(id: request.id, params: request.params)
+        case "moveMouse":
+            response = moveMouse(id: request.id, params: request.params)
+        case "dragMouse":
+            response = dragMouse(id: request.id, params: request.params)
         case "type":
             response = typeText(id: request.id, params: request.params)
         case "pressKey":
             response = pressKey(id: request.id, params: request.params)
+        case "captureScreen":
+            response = captureScreen(id: request.id)
         case "openApp":
             response = openApp(id: request.id, params: request.params)
         case "getWindowList":
@@ -298,6 +306,54 @@ class ClawdCursorHelper {
         
         return JsonRpcResponse(id: id, result: AnyCodable(["success": true, "x": x, "y": y]), error: nil)
     }
+
+    func moveMouse(id: Int, params: [String: AnyCodable]?) -> JsonRpcResponse {
+        guard let x = params?["x"]?.value as? Double,
+              let y = params?["y"]?.value as? Double else {
+            return JsonRpcResponse(id: id, result: nil, error: JsonRpcError(code: -32602, message: "Missing 'x' or 'y' parameter"))
+        }
+        let point = CGPoint(x: x, y: y)
+        if let event = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) {
+            event.post(tap: .cghidEventTap)
+        }
+        return JsonRpcResponse(id: id, result: AnyCodable(["success": true, "x": x, "y": y]), error: nil)
+    }
+
+    func dragMouse(id: Int, params: [String: AnyCodable]?) -> JsonRpcResponse {
+        guard let startX = params?["startX"]?.value as? Double,
+              let startY = params?["startY"]?.value as? Double,
+              let endX = params?["endX"]?.value as? Double,
+              let endY = params?["endY"]?.value as? Double else {
+            return JsonRpcResponse(id: id, result: nil, error: JsonRpcError(code: -32602, message: "Missing drag coordinates"))
+        }
+
+        let startPoint = CGPoint(x: startX, y: startY)
+        let endPoint = CGPoint(x: endX, y: endY)
+        let button: CGMouseButton = .left
+
+        if let mouseDown = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: startPoint, mouseButton: button) {
+            mouseDown.post(tap: .cghidEventTap)
+        }
+        usleep(30000)
+
+        let steps = max(5, Int(hypot(endX - startX, endY - startY) / 20.0))
+        for i in 1...steps {
+            let t = Double(i) / Double(steps)
+            let ix = startX + (endX - startX) * t
+            let iy = startY + (endY - startY) * t
+            let point = CGPoint(x: ix, y: iy)
+            if let drag = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDragged, mouseCursorPosition: point, mouseButton: button) {
+                drag.post(tap: .cghidEventTap)
+            }
+            usleep(12000)
+        }
+
+        if let mouseUp = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: endPoint, mouseButton: button) {
+            mouseUp.post(tap: .cghidEventTap)
+        }
+
+        return JsonRpcResponse(id: id, result: AnyCodable(["success": true]), error: nil)
+    }
     
     func typeText(id: Int, params: [String: AnyCodable]?) -> JsonRpcResponse {
         guard let text = params?["text"]?.value as? String else {
@@ -384,6 +440,39 @@ class ClawdCursorHelper {
         }
         
         return JsonRpcResponse(id: id, result: AnyCodable(["success": true, "key": key, "modifiers": modifiers]), error: nil)
+    }
+
+    func captureScreen(id: Int) -> JsonRpcResponse {
+        guard CGPreflightScreenCaptureAccess() else {
+            return JsonRpcResponse(id: id, result: nil, error: JsonRpcError(code: -32001, message: "screen_recording_denied"))
+        }
+
+        guard let image = CGWindowListCreateImage(
+            CGRect.infinite,
+            .optionOnScreenOnly,
+            kCGNullWindowID,
+            [.nominalResolution]
+        ) else {
+            return JsonRpcResponse(id: id, result: nil, error: JsonRpcError(code: -32000, message: "Failed to capture screen"))
+        }
+
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(data, UTType.png.identifier as CFString, 1, nil) else {
+            return JsonRpcResponse(id: id, result: nil, error: JsonRpcError(code: -32000, message: "Failed to create image destination"))
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return JsonRpcResponse(id: id, result: nil, error: JsonRpcError(code: -32000, message: "Failed to encode screenshot"))
+        }
+
+        let base64 = (data as Data).base64EncodedString()
+        return JsonRpcResponse(id: id, result: AnyCodable([
+            "success": true,
+            "width": image.width,
+            "height": image.height,
+            "format": "png",
+            "imageBase64": base64
+        ]), error: nil)
     }
     
     func openApp(id: Int, params: [String: AnyCodable]?) -> JsonRpcResponse {

--- a/native/Sources/ClawdCursorHost/main.swift
+++ b/native/Sources/ClawdCursorHost/main.swift
@@ -1,0 +1,165 @@
+import Foundation
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Network
+
+private let hostPort: UInt16 = {
+    if let env = ProcessInfo.processInfo.environment["CLAWDCURSOR_HOST_PORT"], let parsed = UInt16(env) {
+        return parsed
+    }
+    return 3848
+}()
+
+private func expectedToken() -> String? {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let tokenPath = home.appendingPathComponent(".clawdcursor/host-token").path
+    return try? String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func jsonResponse(status: Int, payload: Data) -> Data {
+    var response = "HTTP/1.1 \(status) \(status == 200 ? "OK" : "ERROR")\r\n"
+    response += "Content-Type: application/json\r\n"
+    response += "Content-Length: \(payload.count)\r\n"
+    response += "Connection: close\r\n\r\n"
+    var data = Data(response.utf8)
+    data.append(payload)
+    return data
+}
+
+private func textResponse(status: Int, text: String) -> Data {
+    jsonResponse(status: status, payload: Data(text.utf8))
+}
+
+private func runBinary(_ binary: String, args: [String] = [], stdin: Data? = nil) -> (exitCode: Int32, stdout: Data, stderr: Data) {
+    let bundlePath = Bundle.main.bundlePath
+    let macOSDir = URL(fileURLWithPath: bundlePath).appendingPathComponent("Contents/MacOS")
+    let binaryPath = macOSDir.appendingPathComponent(binary).path
+
+    let process = Process()
+    let out = Pipe()
+    let err = Pipe()
+    let input = Pipe()
+
+    process.executableURL = URL(fileURLWithPath: binaryPath)
+    process.arguments = args
+    process.standardOutput = out
+    process.standardError = err
+    process.standardInput = input
+
+    do {
+        try process.run()
+    } catch {
+        return (1, Data(), Data("{\"error\":\"failed_to_launch_binary\"}".utf8))
+    }
+
+    if let stdin {
+        input.fileHandleForWriting.write(stdin)
+    }
+    try? input.fileHandleForWriting.close()
+
+    process.waitUntilExit()
+    let stdout = out.fileHandleForReading.readDataToEndOfFile()
+    let stderr = err.fileHandleForReading.readDataToEndOfFile()
+    return (process.terminationStatus, stdout, stderr)
+}
+
+private func handleRequest(raw: Data) -> Data {
+    guard let request = String(data: raw, encoding: .utf8) else {
+        return textResponse(status: 400, text: "{\"error\":\"invalid_utf8\"}")
+    }
+
+    let parts = request.components(separatedBy: "\r\n\r\n")
+    guard let head = parts.first else {
+        return textResponse(status: 400, text: "{\"error\":\"invalid_request\"}")
+    }
+
+    let lines = head.components(separatedBy: "\r\n")
+    guard let reqLine = lines.first else {
+        return textResponse(status: 400, text: "{\"error\":\"missing_request_line\"}")
+    }
+
+    let reqParts = reqLine.split(separator: " ")
+    guard reqParts.count >= 2 else {
+        return textResponse(status: 400, text: "{\"error\":\"bad_request_line\"}")
+    }
+
+    let method = String(reqParts[0])
+    let path = String(reqParts[1])
+    let body = parts.dropFirst().joined(separator: "\r\n\r\n")
+    var headers: [String: String] = [:]
+    for line in lines.dropFirst() {
+        if let idx = line.firstIndex(of: ":") {
+            let name = String(line[..<idx]).trimmingCharacters(in: .whitespaces).lowercased()
+            let value = String(line[line.index(after: idx)...]).trimmingCharacters(in: .whitespaces)
+            headers[name] = value
+        }
+    }
+
+    if method == "GET" && path == "/health" {
+        let payload = "{\"status\":\"ok\",\"service\":\"clawdcursor-host\",\"port\":\(hostPort)}"
+        return textResponse(status: 200, text: payload)
+    }
+
+    if method == "GET" && path == "/status" {
+        let axOptions = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: kCFBooleanFalse] as CFDictionary
+        let axGranted = AXIsProcessTrustedWithOptions(axOptions)
+        let screenGranted = CGPreflightScreenCaptureAccess()
+        let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
+        let payload = "{\"accessibility\":\(axGranted),\"screenRecording\":\(screenGranted),\"bundleId\":\"\(bundleId)\"}"
+        return textResponse(status: 200, text: payload)
+    }
+
+    if method == "POST" && path == "/rpc" {
+        guard let token = expectedToken(), !token.isEmpty else {
+            return textResponse(status: 503, text: "{\"error\":\"host_token_missing\"}")
+        }
+        guard headers["x-clawdcursor-token"] == token else {
+            return textResponse(status: 401, text: "{\"error\":\"unauthorized\"}")
+        }
+        let result = runBinary("clawdcursor-helper", stdin: Data((body + "\n").utf8))
+        if result.exitCode == 0, !result.stdout.isEmpty {
+            let lines = String(data: result.stdout, encoding: .utf8)?.split(separator: "\n") ?? []
+            if let first = lines.first {
+                return textResponse(status: 200, text: String(first))
+            }
+        }
+        let stderr = String(data: result.stderr, encoding: .utf8) ?? "unknown error"
+        return textResponse(status: 500, text: "{\"error\":\"helper_failed\",\"message\":\"\(stderr.replacingOccurrences(of: "\"", with: "'"))\"}")
+    }
+
+    return textResponse(status: 404, text: "{\"error\":\"not_found\"}")
+}
+
+private var listenerRef: NWListener?
+
+private func startServer() throws {
+    let listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: hostPort)!)
+    listener.newConnectionHandler = { conn in
+        conn.start(queue: .global())
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 1024 * 1024) { data, _, _, _ in
+            let response = handleRequest(raw: data ?? Data())
+            conn.send(content: response, completion: .contentProcessed { _ in
+                conn.cancel()
+            })
+        }
+    }
+    listener.start(queue: .global())
+    listenerRef = listener
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+
+if let bundleId = Bundle.main.bundleIdentifier {
+    NSLog("ClawdCursorHost starting (bundle: \(bundleId), port: \(hostPort))")
+}
+
+try startServer()
+DispatchQueue.main.async {
+    let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    statusItem.button?.title = "🐾"
+    statusItem.button?.toolTip = "ClawdCursor Host"
+}
+
+app.run()

--- a/native/build.sh
+++ b/native/build.sh
@@ -18,6 +18,7 @@ APP_DIR="ClawdCursor.app/Contents/MacOS"
 mkdir -p "$APP_DIR"
 
 # Copy binaries into the bundle
+cp "$BUILD_DIR/ClawdCursorHost" "$APP_DIR/"
 cp "$BUILD_DIR/clawdcursor-helper" "$APP_DIR/"
 cp "$BUILD_DIR/screenshot-helper" "$APP_DIR/"
 cp "$BUILD_DIR/permission-check" "$APP_DIR/"
@@ -52,4 +53,4 @@ echo "To test permissions:"
 echo "  ./ClawdCursor.app/Contents/MacOS/permission-check"
 echo ""
 echo "To run the helper:"
-echo "  ./ClawdCursor.app/Contents/MacOS/clawdcursor-helper"
+echo "  open ClawdCursor.app"

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -256,13 +256,13 @@ export async function runDoctor(opts: {
         ok: axOk,
         detail: axOk
           ? 'Granted — clawdcursor can read UI elements'
-          : 'DENIED — open System Settings → Privacy & Security → Accessibility → enable Terminal/Node',
+          : 'DENIED — open System Settings → Privacy & Security → Accessibility → enable ClawdCursor',
       });
       if (axOk) {
         console.log('   ✅ Accessibility permission granted');
       } else {
         console.log('   ❌ Accessibility permission DENIED');
-        console.log('   → System Settings → Privacy & Security → Accessibility → enable your terminal');
+        console.log('   → System Settings → Privacy & Security → Accessibility → enable ClawdCursor');
       }
     } catch {
       results.push({ name: 'macOS Accessibility permission', ok: false, detail: 'Could not query — run manually in a terminal' });
@@ -282,12 +282,12 @@ export async function runDoctor(opts: {
         name: 'macOS Screen Recording permission',
         ok: !denied,
         detail: denied
-          ? 'DENIED — open System Settings → Privacy & Security → Screen Recording → enable Terminal/Node'
+          ? 'DENIED — open System Settings → Privacy & Security → Screen & System Audio Recording → enable ClawdCursor'
           : 'Granted — clawdcursor can capture the screen',
       });
       if (denied) {
         console.log('   ❌ Screen Recording permission DENIED');
-        console.log('   → System Settings → Privacy & Security → Screen Recording → enable your terminal');
+        console.log('   → System Settings → Privacy & Security → Screen & System Audio Recording → enable ClawdCursor');
       } else {
         console.log('   ✅ Screen Recording permission granted');
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { resolveApiConfig } from './credentials';
 import * as fs from 'fs';
 import * as path from 'path';
 import { migrateFromLegacyDir } from './paths';
+import { ensureHostAppRunning, stopHostApp, checkPermissionsQuick } from './native-helper';
 
 dotenv.config();
 
@@ -175,6 +176,21 @@ program
     } else if (!hasConsent()) {
       const accepted = await runOnboarding('start', parseInt(opts.port, 10) || 3847);
       if (!accepted) process.exit(1);
+    }
+
+    if (process.platform === 'darwin') {
+      await ensureHostAppRunning();
+      const perms = await checkPermissionsQuick();
+      if (!perms.accessibility) {
+        console.error(`\n${e('❌', '[ERR]')} macOS Accessibility permission is not granted to ClawdCursor.`);
+        console.error(`Grant it in: System Settings → Privacy & Security → Accessibility`);
+        console.error(`Then restart with: clawdcursor start\n`);
+        process.exit(1);
+      }
+      if (!perms.screenRecording) {
+        console.warn(`${e('⚠️', '[WARN]')} Screen Recording is not granted to ClawdCursor.`);
+        console.warn(`   Screenshots may fail until enabled in System Settings → Privacy & Security → Screen & System Audio Recording.`);
+      }
     }
 
     // Pre-check: is the port already in use? Do this BEFORE expensive init.
@@ -446,6 +462,9 @@ program
     const isClawd = await isClawdInstance(port);
     if (!isClawd) {
       console.log(`${e('🐾', '>')} No running instance found on port ` + port);
+      if (process.platform === 'darwin') {
+        await stopHostApp();
+      }
       return;
     }
 
@@ -470,6 +489,7 @@ program
     }
 
     // Verify it actually stopped (wait up to 3s)
+    let serverStopped = false;
     for (let i = 0; i < 6; i++) {
       await new Promise(r => setTimeout(r, 500));
       try {
@@ -478,15 +498,22 @@ program
       } catch {
         // Connection refused = dead = success
         console.log(`${e('✅', '[OK]')} Server confirmed stopped`);
-        return;
+        serverStopped = true;
+        break;
       }
     }
-    console.log(`${e('⚠️', '[WARN]')}  Graceful stop did not complete — force killing...`);
-    const killed = await forceKillPort(port);
-    if (killed) {
-      console.log(`${e('🐾', '>')} Clawd Cursor force stopped`);
-    } else {
-      console.error(`${e('❌', '[ERR]')} Could not force stop process on port ` + port);
+    if (!serverStopped) {
+      console.log(`${e('⚠️', '[WARN]')}  Graceful stop did not complete — force killing...`);
+      const killed = await forceKillPort(port);
+      if (killed) {
+        console.log(`${e('🐾', '>')} Clawd Cursor force stopped`);
+      } else {
+        console.error(`${e('❌', '[ERR]')} Could not force stop process on port ` + port);
+      }
+    }
+
+    if (process.platform === 'darwin') {
+      await stopHostApp();
     }
   });
 

--- a/src/native-desktop.ts
+++ b/src/native-desktop.ts
@@ -14,10 +14,12 @@ import { EventEmitter } from 'events';
 import sharp from 'sharp';
 import { mouse, keyboard, screen, Button, Key, Point } from '@nut-tree-fork/nut-js';
 import { normalizeKey } from './keys';
+import { getNativeHelper } from './native-helper';
 import type { ClawdConfig, ScreenFrame, MouseAction, KeyboardAction } from './types';
 
 // On macOS, Command key = Key.LeftCmd. On other platforms, Super = Key.LeftSuper.
 const SUPER_KEY = os.platform() === 'darwin' ? Key.LeftCmd : Key.LeftSuper;
+const IS_MAC = os.platform() === 'darwin';
 
 /** Safely resolve a nut-js Key enum value from multiple candidate names */
 function resolveNutKey(...candidates: string[]): Key {
@@ -80,6 +82,7 @@ export class NativeDesktop extends EventEmitter {
   private screenHeight = 0;
   private connected = false;
   private monitors: MonitorInfo[] = [];
+  private helper = IS_MAC ? getNativeHelper() : null;
 
   /** Scale factor: LLM coordinates × scaleFactor = real screen coordinates */
   private scaleFactor = 1;
@@ -187,6 +190,18 @@ export class NativeDesktop extends EventEmitter {
    */
   async connect(): Promise<void> {
     try {
+      if (IS_MAC && this.helper) {
+        const frame = await this.helper.captureScreen();
+        this.screenWidth = frame.width;
+        this.screenHeight = frame.height;
+        this.scaleFactor = this.screenWidth > LLM_TARGET_WIDTH ? this.screenWidth / LLM_TARGET_WIDTH : 1;
+        this.connected = true;
+        console.log(`🐾 Native desktop connected (macOS host path)`);
+        console.log(`   Screen: ${this.screenWidth}x${this.screenHeight}`);
+        console.log(`   LLM scale factor: ${this.scaleFactor.toFixed(2)}x`);
+        return;
+      }
+
       // Configure nut-js for speed
       mouse.config.mouseSpeed = 2000;    // Fast mouse movement
       mouse.config.autoDelayMs = 0;      // No auto-delay between actions
@@ -278,6 +293,19 @@ export class NativeDesktop extends EventEmitter {
       throw new Error('Not connected to native desktop');
     }
 
+    if (IS_MAC && this.helper) {
+      const frame = await this.helper.captureScreen();
+      this.screenWidth = frame.width;
+      this.screenHeight = frame.height;
+      return {
+        width: frame.width,
+        height: frame.height,
+        buffer: Buffer.from(frame.imageBase64, 'base64'),
+        timestamp: Date.now(),
+        format: 'png',
+      };
+    }
+
     const img = await screen.grab();
 
     // Update screen dimensions in case of resolution change
@@ -312,6 +340,29 @@ export class NativeDesktop extends EventEmitter {
   async captureForLLM(): Promise<ScreenFrame & { scaleFactor: number; llmWidth: number; llmHeight: number }> {
     if (!this.connected) {
       throw new Error('Not connected to native desktop');
+    }
+
+    if (IS_MAC && this.helper) {
+      const frame = await this.captureScreen();
+      this.screenWidth = frame.width;
+      this.screenHeight = frame.height;
+      this.scaleFactor = this.screenWidth > LLM_TARGET_WIDTH ? this.screenWidth / LLM_TARGET_WIDTH : 1;
+      const llmWidth = Math.min(this.screenWidth, LLM_TARGET_WIDTH);
+      const llmHeight = Math.round(this.screenHeight / this.scaleFactor);
+      const pipeline = sharp(frame.buffer).resize(llmWidth, llmHeight);
+      const processed = this.config.capture.format === 'jpeg'
+        ? await pipeline.jpeg({ quality: this.config.capture.quality }).toBuffer()
+        : await pipeline.png().toBuffer();
+      return {
+        width: this.screenWidth,
+        height: this.screenHeight,
+        buffer: processed,
+        timestamp: Date.now(),
+        format: this.config.capture.format,
+        scaleFactor: this.scaleFactor,
+        llmWidth,
+        llmHeight,
+      };
     }
 
     const img = await screen.grab();
@@ -362,6 +413,24 @@ export class NativeDesktop extends EventEmitter {
     x: number, y: number, w: number, h: number
   ): Promise<ScreenFrame & { scaleFactor: number; llmWidth: number; llmHeight: number; regionX: number; regionY: number }> {
     if (!this.connected) throw new Error('Not connected');
+
+    if (IS_MAC && this.helper) {
+      const full = await this.captureScreen();
+      const rx = Math.max(0, Math.min(x, full.width - 1));
+      const ry = Math.max(0, Math.min(y, full.height - 1));
+      const rw = Math.min(w, full.width - rx);
+      const rh = Math.min(h, full.height - ry);
+      const cropScale = rw > LLM_TARGET_WIDTH ? rw / LLM_TARGET_WIDTH : 1;
+      const llmWidth = Math.min(rw, LLM_TARGET_WIDTH);
+      const llmHeight = Math.round(rh / cropScale);
+      const { format, quality } = this.config.capture;
+      let pipeline = sharp(full.buffer).extract({ left: rx, top: ry, width: rw, height: rh });
+      if (llmWidth < rw) {
+        pipeline = pipeline.resize(llmWidth, llmHeight, { fit: 'fill', kernel: 'lanczos3' });
+      }
+      const buffer = format === 'jpeg' ? await pipeline.jpeg({ quality }).toBuffer() : await pipeline.png().toBuffer();
+      return { width: rw, height: rh, buffer, timestamp: Date.now(), format, scaleFactor: cropScale, llmWidth, llmHeight, regionX: rx, regionY: ry };
+    }
 
     const img = await screen.grab();
 
@@ -473,6 +542,10 @@ export class NativeDesktop extends EventEmitter {
 
   async mouseClick(x: number, y: number, button: number = 1): Promise<void> {
     if (!this.connected) throw new Error('Not connected');
+    if (IS_MAC && this.helper) {
+      await this.helper.click(x, y, { button: button === 4 ? 'right' : 'left' });
+      return;
+    }
     await mouse.setPosition(new Point(x, y));
     await this.delay(50);
     const btn = this.mapButton(button);
@@ -482,6 +555,10 @@ export class NativeDesktop extends EventEmitter {
 
   async mouseDoubleClick(x: number, y: number): Promise<void> {
     if (!this.connected) throw new Error('Not connected');
+    if (IS_MAC && this.helper) {
+      await this.helper.click(x, y, { button: 'left', clickCount: 2 });
+      return;
+    }
     await mouse.setPosition(new Point(x, y));
     await this.delay(50);
     await mouse.doubleClick(Button.LEFT);
@@ -490,6 +567,10 @@ export class NativeDesktop extends EventEmitter {
 
   async mouseRightClick(x: number, y: number): Promise<void> {
     if (!this.connected) throw new Error('Not connected');
+    if (IS_MAC && this.helper) {
+      await this.helper.click(x, y, { button: 'right' });
+      return;
+    }
     await mouse.setPosition(new Point(x, y));
     await this.delay(50);
     await mouse.rightClick();
@@ -498,6 +579,10 @@ export class NativeDesktop extends EventEmitter {
 
   async mouseMove(x: number, y: number): Promise<void> {
     if (!this.connected) throw new Error('Not connected');
+    if (IS_MAC && this.helper) {
+      await this.helper.moveMouse(x, y);
+      return;
+    }
     await mouse.setPosition(new Point(x, y));
   }
 
@@ -519,12 +604,32 @@ export class NativeDesktop extends EventEmitter {
 
   async typeText(text: string): Promise<void> {
     if (!this.connected) throw new Error('Not connected');
+    if (IS_MAC && this.helper) {
+      await this.helper.type(text);
+      return;
+    }
     await keyboard.type(text);
     console.log(`   ⌨️  Typed: "${text.substring(0, 60)}${text.length > 60 ? '...' : ''}"`);
   }
 
   async keyPress(keyCombo: string): Promise<void> {
     if (!this.connected) throw new Error('Not connected');
+    if (IS_MAC && this.helper) {
+      if (keyCombo === '+') {
+        await this.helper.type('+');
+        return;
+      }
+      const parts = keyCombo.split('+').map(k => k.trim()).filter(Boolean);
+      const key = parts[parts.length - 1] || keyCombo;
+      const modifiers = parts.slice(0, -1).map(k => {
+        const lower = k.toLowerCase();
+        if (lower === 'super') return 'cmd';
+        if (lower === 'control') return 'ctrl';
+        return lower;
+      });
+      await this.helper.pressKey(key, modifiers);
+      return;
+    }
 
     // Special case: literal "+" character (can't split on "+" since it IS the separator)
     if (keyCombo === '+') {
@@ -656,6 +761,10 @@ export class NativeDesktop extends EventEmitter {
 
   async mouseDrag(sx: number, sy: number, ex: number, ey: number): Promise<void> {
     if (!this.connected) throw new Error('Not connected');
+    if (IS_MAC && this.helper) {
+      await this.helper.dragMouse(sx, sy, ex, ey);
+      return;
+    }
     console.log(`   🖱️  Drag (${sx},${sy}) → (${ex},${ey})`);
 
     await mouse.setPosition(new Point(sx, sy));

--- a/src/native-helper.ts
+++ b/src/native-helper.ts
@@ -12,6 +12,9 @@ import * as os from 'os';
 import * as readline from 'readline';
 
 const IS_MACOS = process.platform === 'darwin';
+const HOST_PORT = parseInt(process.env.CLAWDCURSOR_HOST_PORT || '3848', 10);
+const HOST_BASE_URL = `http://127.0.0.1:${HOST_PORT}`;
+const ALLOW_MAC_FALLBACK = process.env.CLAWDCURSOR_ALLOW_MAC_HELPER_FALLBACK === '1';
 
 interface JsonRpcRequest {
   id: number;
@@ -52,6 +55,14 @@ interface WindowInfo {
   bounds: { X: number; Y: number; Width: number; Height: number };
 }
 
+interface CapturedScreen {
+  success: boolean;
+  width: number;
+  height: number;
+  format: 'png';
+  imageBase64: string;
+}
+
 export class NativeHelper {
   private process: ChildProcess | null = null;
   private requestId = 0;
@@ -60,6 +71,7 @@ export class NativeHelper {
     reject: (error: Error) => void;
   }>();
   private readline: readline.Interface | null = null;
+  private useHostIpc = IS_MACOS;
 
   /**
    * Check if native helper is available (macOS only)
@@ -74,18 +86,18 @@ export class NativeHelper {
     }
   }
 
-  private getHelperPath(): string {
+  private getHelperPath(binary = 'clawdcursor-helper'): string {
     if (!IS_MACOS) {
       throw new Error('Native helper is only available on macOS');
     }
     // Look for the helper in various locations
     const locations = [
       // Development: native/ClawdCursor.app
-      path.join(__dirname, '..', 'native', 'ClawdCursor.app', 'Contents', 'MacOS', 'clawdcursor-helper'),
+      path.join(__dirname, '..', 'native', 'ClawdCursor.app', 'Contents', 'MacOS', binary),
       // Installed via npm: node_modules/.clawdcursor/ClawdCursor.app
-      path.join(__dirname, '..', 'node_modules', '.clawdcursor', 'ClawdCursor.app', 'Contents', 'MacOS', 'clawdcursor-helper'),
+      path.join(__dirname, '..', 'node_modules', '.clawdcursor', 'ClawdCursor.app', 'Contents', 'MacOS', binary),
       // Global install
-      path.join(os.homedir(), '.clawdcursor', 'ClawdCursor.app', 'Contents', 'MacOS', 'clawdcursor-helper'),
+      path.join(os.homedir(), '.clawdcursor', 'ClawdCursor.app', 'Contents', 'MacOS', binary),
     ];
 
     for (const loc of locations) {
@@ -103,6 +115,10 @@ export class NativeHelper {
   async start(): Promise<void> {
     if (!IS_MACOS) {
       throw new Error('Native helper is only available on macOS');
+    }
+    if (this.useHostIpc) {
+      await ensureHostAppRunning();
+      return;
     }
     if (this.process) return;
 
@@ -154,6 +170,7 @@ export class NativeHelper {
   }
 
   async stop(): Promise<void> {
+    if (this.useHostIpc) return;
     if (this.process) {
       this.process.kill();
       this.process = null;
@@ -162,12 +179,33 @@ export class NativeHelper {
   }
 
   private async call<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+    const id = ++this.requestId;
+    const request: JsonRpcRequest = { id, method, params };
+
+    if (this.useHostIpc) {
+      await ensureHostAppRunning();
+      const res = await fetch(`${HOST_BASE_URL}/rpc`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-clawdcursor-token': getOrCreateHostToken(),
+        },
+        body: JSON.stringify(request),
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!res.ok) {
+        throw new Error(`Host IPC call failed (${res.status})`);
+      }
+      const rpc = await res.json() as JsonRpcResponse;
+      if (rpc.error) {
+        throw new Error(`${rpc.error.message} (code ${rpc.error.code})`);
+      }
+      return rpc.result as T;
+    }
+
     if (!this.process) {
       await this.start();
     }
-
-    const id = ++this.requestId;
-    const request: JsonRpcRequest = { id, method, params };
 
     return new Promise((resolve, reject) => {
       // Guard against process dying between start() and write()
@@ -217,6 +255,14 @@ export class NativeHelper {
     return this.call('click', { x, y, ...options });
   }
 
+  async moveMouse(x: number, y: number): Promise<{ success: boolean; x: number; y: number }> {
+    return this.call('moveMouse', { x, y });
+  }
+
+  async dragMouse(startX: number, startY: number, endX: number, endY: number): Promise<{ success: boolean }> {
+    return this.call('dragMouse', { startX, startY, endX, endY });
+  }
+
   async type(text: string, options?: { delayMs?: number }): Promise<{ success: boolean; length: number }> {
     return this.call('type', { text, ...options });
   }
@@ -231,6 +277,10 @@ export class NativeHelper {
 
   async getWindowList(): Promise<{ windows: WindowInfo[] }> {
     return this.call('getWindowList');
+  }
+
+  async captureScreen(): Promise<CapturedScreen> {
+    return this.call('captureScreen');
   }
 }
 
@@ -269,9 +319,18 @@ export async function checkPermissionsQuick(): Promise<PermissionStatus> {
     };
   }
 
-  const permissionCheckPath = path.join(
-    __dirname, '..', 'native', 'ClawdCursor.app', 'Contents', 'MacOS', 'permission-check'
-  );
+  if (await isHostRunning()) {
+    const res = await fetch(`${HOST_BASE_URL}/status`, { signal: AbortSignal.timeout(5000) });
+    if (res.ok) {
+      return res.json() as Promise<PermissionStatus>;
+    }
+  }
+
+  if (!ALLOW_MAC_FALLBACK) {
+    throw new Error('ClawdCursor host is required on macOS. Build/launch ClawdCursor.app or set CLAWDCURSOR_ALLOW_MAC_HELPER_FALLBACK=1 for temporary dev fallback.');
+  }
+
+  const permissionCheckPath = getNativeHelperPath('permission-check');
 
   if (!fs.existsSync(permissionCheckPath)) {
     // Fall back to full helper
@@ -305,6 +364,81 @@ export async function checkPermissionsQuick(): Promise<PermissionStatus> {
       }
     });
   });
+}
+
+function getNativeHelperPath(binary: string): string {
+  const locations = [
+    path.join(__dirname, '..', 'native', 'ClawdCursor.app', 'Contents', 'MacOS', binary),
+    path.join(__dirname, '..', 'node_modules', '.clawdcursor', 'ClawdCursor.app', 'Contents', 'MacOS', binary),
+    path.join(os.homedir(), '.clawdcursor', 'ClawdCursor.app', 'Contents', 'MacOS', binary),
+  ];
+  for (const loc of locations) {
+    if (fs.existsSync(loc)) return loc;
+  }
+  throw new Error(`ClawdCursor app binary not found: ${binary}`);
+}
+
+export async function isHostRunning(): Promise<boolean> {
+  if (!IS_MACOS) return false;
+  try {
+    const res = await fetch(`${HOST_BASE_URL}/health`, { signal: AbortSignal.timeout(1500) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureHostAppRunning(): Promise<void> {
+  if (!IS_MACOS) return;
+  if (await isHostRunning()) return;
+
+  const appExecutable = getNativeHelperPath('ClawdCursorHost');
+  const appPath = path.resolve(appExecutable, '..', '..', '..');
+  await new Promise<void>((resolve, reject) => {
+    const opener = spawn('open', ['-a', appPath], { stdio: 'ignore' });
+    opener.on('error', reject);
+    opener.on('close', () => resolve());
+  });
+
+  const started = Date.now();
+  while (Date.now() - started < 10000) {
+    if (await isHostRunning()) return;
+    await new Promise(r => setTimeout(r, 250));
+  }
+  throw new Error('ClawdCursor host app did not start in time');
+}
+
+export async function stopHostApp(): Promise<void> {
+  if (!IS_MACOS) return;
+  await new Promise<void>((resolve) => {
+    const proc = spawn('osascript', ['-e', 'tell application id "com.clawdcursor.app" to quit'], { stdio: 'ignore' });
+    proc.on('close', () => resolve());
+    proc.on('error', () => resolve());
+  });
+
+  const started = Date.now();
+  while (Date.now() - started < 3000) {
+    if (!(await isHostRunning())) return;
+    await new Promise(r => setTimeout(r, 200));
+  }
+  // stale process recovery
+  await new Promise<void>((resolve) => {
+    const proc = spawn('pkill', ['-f', 'ClawdCursorHost'], { stdio: 'ignore' });
+    proc.on('close', () => resolve());
+    proc.on('error', () => resolve());
+  });
+}
+
+function getOrCreateHostToken(): string {
+  const dir = path.join(os.homedir(), '.clawdcursor');
+  const tokenPath = path.join(dir, 'host-token');
+  if (fs.existsSync(tokenPath)) {
+    return fs.readFileSync(tokenPath, 'utf-8').trim();
+  }
+  fs.mkdirSync(dir, { recursive: true });
+  const token = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 18)}`;
+  fs.writeFileSync(tokenPath, token, { mode: 0o600 });
+  return token;
 }
 
 /**

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -110,11 +110,11 @@ export async function getReadinessStatus(): Promise<ReadinessStatus> {
   if (isMacOS() && macPermissions) {
     if (!macPermissions.accessibility) {
       issues.push('macOS Accessibility permission not granted');
-      nextSteps.push('System Settings → Privacy & Security → Accessibility → Enable ClawdCursor/Terminal');
+      nextSteps.push('System Settings → Privacy & Security → Accessibility → Enable ClawdCursor');
     }
     if (!macPermissions.screenRecording) {
       issues.push('macOS Screen Recording permission not granted');
-      nextSteps.push('System Settings → Privacy & Security → Screen Recording → Enable ClawdCursor/Terminal');
+      nextSteps.push('System Settings → Privacy & Security → Screen & System Audio Recording → Enable ClawdCursor');
     }
   }
   


### PR DESCRIPTION
### Motivation

- Centralize macOS TCC permissions under a single bundled app identity (`ClawdCursor.app`) and provide a long-lived host process to own IPC and permission-sensitive operations.
- Enable richer native desktop control (smooth mouse moves/drags and screenshots) while avoiding unbundled-binary TCC issues on macOS.

### Description

- Add a new host executable `ClawdCursorHost` with a small HTTP IPC server (`127.0.0.1:<port>`) and token auth, and register it in `Package.swift` and the app bundle (`Info.plist`).
- Update build flow (`native/build.sh`) to include `ClawdCursorHost` in the `ClawdCursor.app` bundle and change the default run hint to `open ClawdCursor.app`.
- Extend the Swift helper (`ClawdCursorHelper`) with new JSON-RPC methods: `moveMouse`, `dragMouse`, and `captureScreen` (PNG base64 encoding), and add required imports (`ImageIO`, `UniformTypeIdentifiers`).
- Add `Sources/ClawdCursorHost/main.swift` implementing the host listener, health/status endpoints, and proxying JSON-RPC `POST /rpc` to `clawdcursor-helper` when authorized.
- Rework Node-side native integration (`src/native-helper.ts`) to prefer communicating with the host IPC (`/health`, `/status`, `/rpc`), add utility functions (`isHostRunning`, `ensureHostAppRunning`, `stopHostApp`, token management), and provide fallback behavior controlled via `CLAWDCURSOR_ALLOW_MAC_HELPER_FALLBACK`.
- Wire the native helper into the desktop stack: `src/native-desktop.ts` now uses the native helper for captures, mouse moves/drags, typing and key presses on macOS when available; `src/index.ts`, `src/doctor.ts`, and `src/readiness.ts` updated to ensure the host is running and to reference `ClawdCursor` in user-facing messages.
- Add helper path resolution utilities and tighten permission-check behavior to prefer the host status endpoint before falling back to bundled `permission-check` binary.
- Update `native/README.md` to document the new `ClawdCursorHost` IPC endpoints and workflow.

### Testing

- Built native Swift targets via the updated build script (`./native/build.sh` which runs `swift build -c release`) and confirmed `ClawdCursor.app` artifacts were produced successfully.
- Compiled the TypeScript codebase (`npm run build`) to ensure updated imports and types pass compilation.
- Performed basic host sanity checks by starting `ClawdCursorHost` and verifying `GET /health` and `GET /status` return expected JSON (local smoke tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5a23b1fa883278a87fd20257e8126)