### PR TITLE
release: v0.8.4 security maintenance + v0.8.5 review-fix maintenance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Force LF for files compared byte-for-byte by tooling, so Windows
+# autocrlf=true checkouts don't break tests that hash-compare against
+# content written with explicit '\n' separators.
+schema.snapshot.json text eol=lf
+
+# JSON files generally — keep stable across platforms.
+*.json text eol=lf
+
+# Shell scripts must stay LF on every platform (CRLF breaks /usr/bin/env
+# shebangs and bash heredocs).
+*.sh text eol=lf
+
+# Other text files: let git normalize on commit, check out with the
+# platform's native EOL.
+* text=auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Clawd Cursor will be documented in this file.
 
+## [0.8.4] - 2026-04-21 — Security maintenance + README rewrite
+
+Dependency audit release. No functional changes, no schema changes, 429/430 tests still pass.
+
+### Security
+
+Patched every fixable advisory in the dependency tree (5 of 12 surfaced by `npm audit`). The remaining 7 moderate alerts all chain through `jimp → @nut-tree-fork/nut-js` and have no upstream fix yet; tracked for a follow-up once nut-js releases a jimp upgrade.
+
+- **`vite`** → 7.3.2+ · **High** · path traversal in optimized-deps `.map` handling ([GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9)), `server.fs.deny` bypass via query strings ([GHSA-v2wj-q39q-566r](https://github.com/advisories/GHSA-v2wj-q39q-566r)), arbitrary file read via dev-server WebSocket ([GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583)).
+- **`path-to-regexp`** → 0.1.13+ · **High** · ReDoS via multiple route parameters ([GHSA-37ch-88jc-xwx2](https://github.com/advisories/GHSA-37ch-88jc-xwx2)).
+- **`picomatch`** → 4.0.4+ · **High** · method injection in POSIX character classes + ReDoS via extglob quantifiers ([GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p), [GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj)).
+- **`hono`** → 4.12.14+ · Moderate · HTML injection in `hono/jsx` SSR via unsafe attribute names ([GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375)).
+- **`follow-redirects`** → 1.15.12+ · Moderate · custom auth headers leaked across cross-domain redirects ([GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653)).
+
+### Changed
+
+- **README rewrite.** Removed stale "What's New in v0.8.0 — V2 Architecture" headliner (v0.8.0's V2-vs-legacy split was unified in v0.8.2 — no opt-in flag, no two pipelines). Pipeline section now reflects the unified blind → hybrid → vision router, the `safety.evaluate()` chokepoint, ground-truth verification, and the v0.8.3 runaway guard. Tool surface reorganized around the 6-tool compact catalog and the 74-tool granular catalog. Tone tightened; marketing phrasing trimmed.
+
+---
+
 ## [0.8.3] - 2026-04-19 — Hotfix: "Outlook keeps opening" + runaway guard
 
 User reported Outlook launching repeatedly during a test. Root-cause diagnosis traced to three compounding failures: (1) `PlatformAdapter.openApp` spawned a new instance even when the app was already running, (2) the escalation ladder (router → blind → hybrid → vision) re-ran `open_app` at each rung because earlier rungs couldn't verify success through New Outlook's sparse WebView2 accessibility tree, (3) `clawdcursor stop` only killed the `start` process on port 3847, missing `serve` (different port / same port different process) and `mcp` (stdio, no port) entirely. A stale `serve` kept receiving MCP traffic after the user thought they'd stopped everything.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to Clawd Cursor will be documented in this file.
 
+## [0.8.5] - 2026-04-30 — Review-fix maintenance + compact-tool keyboard fix
+
+Two remote review passes (six findings + ten findings) on the v0.8.4 docs uncovered one real behavior bug, several factually wrong install instructions, and a long tail of documentation drift that had built up across SKILL.md, README, docs/index.html, and source comments. This release closes all of it. 429/430 tests still pass; granular schema snapshot unchanged.
+
+### Fixed
+
+- **`computer({"action":"key","combo":"..."})` now works.** The compound `key` / `key_press` / `key_down` / `key_up` actions had no `argRemap`, so the schema exposed `key` (not `combo`). REST rejected `combo` as an unknown parameter; MCP silently dropped it and the granular handler crashed with `(undefined).toLowerCase()`. Implemented the remap that `compact.ts:46-47` had documented as the canonical example since v0.8.1 — `argRemap: { combo: 'key' }` on all four keyboard actions. Granular schema is unaffected; the `key` granular tool still takes `key`. `src/tools/compact.ts`.
+- **Stale "72 granular tools" count** in user-visible places — `clawdcursor mcp --help`, the markdown returned by `GET /docs`, plus four internal source comments. CHANGELOG v0.8.2 established 74 (72 + 2 Electron-bridge tools) as canonical; the agent-facing surfaces are now consistent. `src/index.ts`, `src/tool-server.ts`, `src/tools/compact.ts`, `src/tools/index.ts`.
+
+### Documentation
+
+- **README installer claims rewritten.** The previous wording falsely claimed the installer (1) drops files into `~/.clawdcursor`, (2) registers an MCP server in `~/.claude/settings.json`, and (3) copies SKILL.md into every detected agent's skill directory. Verified against `docs/install.sh` and `docs/install.ps1`: the installer only clones to `~/clawdcursor` (no dot), runs `npm install + build`, and `npm link`s the global shim. The dotted `~/.clawdcursor/` directory holds runtime state only. Wiring the skill into Claude Code now correctly says the JSON block is required, not optional.
+- **Compact-action surface corrections.** The README's compact-tool table used invented action names — `accessibility.read_screen` (actual: `read_tree`), `accessibility.get_focused` (`focused`), `window.set_state`/`set_bounds`/`get_active` (none exist), `system.open_app` (lives on `window`), `system.read_clipboard` (`clipboard_read`), `browser.navigate` (lives on `window`), and the entire `task` action enum (`task` has no enum — just `{instruction}`). All rewritten against `src/tools/compact.ts`. Marquee example also fixed to use real calls.
+- **Linux accessibility package.** Was `at-spi2-core` + `python3-gi`; the actual missing package on a fresh Ubuntu install is `gir1.2-atspi-2.0` (the AT-SPI typelib that `python3-gi` consumes). Brought into line with SKILL.md, the probe script's hint, and the platform adapter docstring.
+- **Compact-action tables now non-exhaustive by default.** Added a "Most-used actions" header + caveat pointing to `GET /tools?mode=compact`, and filled in the high-value entries that had been silently dropped (`accessibility.list_children`, `browser.page_context`, `window.list_displays` / `screen_size` / `switch_tab`, `computer.scroll_horizontal` / `triple_click`).
+- **`clawdcursor dashboard` removed** from the README CLI block — that command never existed; the dashboard is reachable at `http://127.0.0.1:3847` while `serve` or `start` is running. `status` and `consent` subcommands added to the CLI block since they were referenced in the Options block but never introduced.
+- **`--compact` / `--accept` flag scopes corrected.** README claimed `--compact` works on `serve`; it's mcp-only (`serve` uses `?mode=compact` on `GET /tools`). README claimed `--accept` is universal; it lives on `start` and `consent` (`serve` uses `--skip-consent`).
+- **"Anthropic Agent SDK" → "Claude Agent SDK"** (the official product name) across README.
+- **`invoke_element` recategorized** from "Window / App" to "Accessibility" in the README — matches its registration in `src/tools/a11y_depth.ts` and the SKILL.md taxonomy.
+- **`docs/index.html` install snippets** no longer push `clawdcursor start` as the canonical post-install step (contradicts the new "skill, not application" framing). Replaced with `clawdcursor doctor` (verify-the-install) and a footer note that `start` is testing-only. Hero badge CVE list now includes `follow-redirects`.
+- **SKILL.md `/health` example** now uses `<x.y.z>` placeholder instead of a hard-coded version that drifts every release. "What's new" section expanded to cover 0.8.4 + 0.8.3 + 0.8.2.
+- **Cost-tier ladder + "no task is impossible" callout** added to SKILL.md (lines 38, 108-118). Sets the default agent disposition: GUI + mouse + keyboard = everything you need; start at T1 (structured a11y), escalate only when the current tier fails.
+- **Skill-first README rewrite.** The headline now reads "The skill that gives any AI agent eyes, hands, and a keyboard on a real desktop." `start` / `task` are demoted to a "Testing and Troubleshooting" appendix with explicit guidance that agents should not invoke them — they go through MCP or the REST surface. Replaces the earlier "OS-level desktop automation server" framing.
+- **Stale tagline cleanup.** Removed "ears" (no audio capture exists in `src/`) from `package.json` description, SKILL.md frontmatter, and `docs/index.html` meta tags + agent-readable summary. Aligned with the README's existing "eyes, hands, and a keyboard" wording.
+- **Pre-existing fix while in the area:** dropped the blocking `clawdcursor serve` step from `metadata.openclaw.install` in SKILL.md. `serve` is a foreground HTTP server with no auto-exit; using it as a sequential install step would either hang the installer or leave a zombie daemon — directly contradicts the "nothing runs in the foreground" framing.
+
+### Verified, not changed
+
+- **Cmd+Q is blocked.** Review claimed Cmd+Q is not actually blocked by the safety layer. Verified against `src/pipeline/playbooks/keys-blocklist.ts:24` + `src/pipeline/safety/layer.ts:325-328`: it IS blocked through the SafetyLayer chokepoint via both `combo` and `key` arg paths. README is correct; no change needed.
+
+---
+
 ## [0.8.4] - 2026-04-21 — Security maintenance + README rewrite
 
 Dependency audit release. No functional changes, no schema changes, 429/430 tests still pass.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ You install it once. Any tool-calling agent on the machine &mdash; Claude Code, 
 ```
 User: "Open Outlook and reply to the latest email from Sarah."
 
-Agent  →  system.open_app("Outlook")
-       →  accessibility.read_screen()
-       →  computer.click(sarah_email_row)
-       →  computer.key("Ctrl+R")
-       →  computer.type("...")
-       →  computer.click(send_button)
+Agent  →  window({"action":"open_app","name":"Outlook"})
+       →  accessibility({"action":"read_tree"})
+       →  accessibility({"action":"invoke","name":"Sarah's email"})
+       →  computer({"action":"key","combo":"mod+r"})
+       →  computer({"action":"type","text":"..."})
+       →  accessibility({"action":"invoke","name":"Send"})
        → done (verified by ground-truth verifier)
 ```
 
@@ -143,26 +143,27 @@ Anthropic `computer_20250124`-style: one tool per capability, with an `action` e
 
 | Tool | Actions |
 |---|---|
-| `computer` | `screenshot`, `click`, `type`, `key`, `scroll`, `drag`, `drag_path`, `wait` |
-| `accessibility` | `read_screen`, `find`, `get_focused`, `wait_for_element`, `invoke` |
-| `window` | `list`, `focus`, `set_state`, `set_bounds`, `get_active` |
-| `system` | `open_app`, `detect_webview`, `relaunch_with_cdp`, `read_clipboard`, `write_clipboard` |
-| `browser` | `connect`, `click`, `type`, `read_text`, `evaluate`, `navigate` |
-| `task` | `delegate`, `status`, `confirm`, `abort` |
+| `computer` | `screenshot`, `click`, `double_click`, `right_click`, `hover`, `move_relative`, `scroll`, `drag`, `drag_path`, `type`, `key`, `wait` |
+| `accessibility` | `read_tree`, `find`, `get_element`, `focused`, `invoke`, `focus`, `set_value`, `get_value`, `expand`, `collapse`, `toggle`, `select`, `state`, `wait_for` |
+| `window` | `list`, `active`, `focus`, `maximize`, `minimize`, `restore`, `close`, `resize`, `open_app`, `open_file`, `open_url`, `navigate` |
+| `system` | `clipboard_read`, `clipboard_write`, `system_time`, `ocr`, `undo`, `shortcuts_list`, `shortcuts_run`, `delegate`, `detect_webview`, `relaunch_with_cdp` |
+| `browser` | `connect`, `read_text`, `click`, `type`, `select_option`, `evaluate`, `wait_for`, `list_tabs`, `switch_tab`, `scroll` |
+| `task` | (no `action` enum &mdash; takes `{instruction: string}` and routes through the full pipeline) |
 
 ### Granular &mdash; 74 individual tools
 
-Full catalog for agents that prefer one tool per verb. Grouped by capability:
+Full catalog for agents that prefer one tool per verb. Sample of categories below; the full list is at `GET /tools` or `list_tools` over MCP.
 
-| Category | Count | Examples |
-|---|---|---|
-| Perception | 9 | `screenshot`, `read_screen`, `smart_read`, `ocr_read_screen` |
-| Mouse | 6 | `mouse_click`, `mouse_double_click`, `mouse_drag`, `mouse_drag_stepped`, `mouse_scroll` |
-| Keyboard | 5 | `key_press`, `type_text`, `smart_type`, `shortcuts_list`, `shortcuts_execute` |
-| Window / App | 8 | `focus_window`, `open_app`, `get_windows`, `invoke_element`, `detect_webview_apps` |
-| Browser (CDP) | 10 | `cdp_connect`, `cdp_click`, `cdp_type`, `cdp_read_text`, `cdp_evaluate` |
-| Accessibility | 6 | `get_ui_tree`, `find_elements`, `wait_for_element`, `get_focused_element` |
-| Orchestration | 6 | `smart_click`, `navigate_browser`, `delegate_to_agent`, `wait` |
+| Category | Examples |
+|---|---|
+| Perception | `read_screen`, `desktop_screenshot`, `desktop_screenshot_region`, `ocr_read_screen`, `smart_read` |
+| Mouse | `mouse_click`, `mouse_double_click`, `mouse_drag`, `mouse_drag_stepped`, `mouse_scroll` |
+| Keyboard | `key_press`, `type_text`, `smart_type`, `shortcuts_list`, `shortcuts_execute` |
+| Window / App | `focus_window`, `open_app`, `get_windows`, `invoke_element`, `detect_webview_apps` |
+| Browser (CDP) | `cdp_connect`, `cdp_click`, `cdp_type`, `cdp_read_text`, `cdp_evaluate` |
+| Accessibility | `find_element`, `wait_for_element`, `get_focused_element`, `a11y_expand`, `a11y_toggle` |
+| System | `read_clipboard`, `write_clipboard`, `get_system_time`, `undo_last`, `delegate_to_agent` |
+| Orchestration | `smart_click`, `navigate_browser`, `wait` |
 
 Full catalog visible to the agent through MCP `list_tools` or at `GET /tools`.
 
@@ -271,17 +272,20 @@ clawdcursor start        Run the built-in autonomous agent (testing)
 clawdcursor task <t>     Send a task to that agent (testing)
 
 Options:
-  --port <port>          Default: 3847
-  --compact              Expose compact 6-tool surface (MCP / serve)
-  --provider <name>      Only for `start`: anthropic | openai | gemini | ollama | ...
-  --accept               Skip the consent prompt (non-interactive)
+  --port <port>          Default: 3847 (start, serve, stop, task, status)
+  --compact              MCP only: expose 6 compound tools instead of 74 granular.
+                         For REST/serve, use the `?mode=compact` query parameter
+                         on `GET /tools` instead.
+  --provider <name>      `start` only: anthropic | openai | gemini | ollama | ...
+  --accept               `start` and `consent` only: skip the consent prompt.
+                         For `serve`, use `--skip-consent` (dev environments).
 ```
 
 ---
 
 ## Tech Stack
 
-TypeScript · Node.js 20+ · nut-js · Playwright · sharp · Express · Hono · Model Context Protocol SDK · Zod
+TypeScript · Node.js 20+ · nut-js · Playwright · sharp · Express · Model Context Protocol SDK · Zod · commander
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 Clawd Cursor is a **skill**, not an application. It gives an AI agent the ability to use the user's computer &mdash; mouse, keyboard, screen, windows, browser &mdash; the same way a human would.
 
-You install it once. Any tool-calling agent on the machine &mdash; Claude Code, Cursor, Windsurf, OpenClaw, the Anthropic Agent SDK, or a bring-your-own-model setup &mdash; picks it up automatically through MCP or the skill registry. The agent then knows how to click, type, read the screen, open apps, and drive GUIs whenever the task requires it.
+You install it once. Any tool-calling agent on the machine &mdash; Claude Code, Cursor, Windsurf, OpenClaw, the Claude Agent SDK, or a bring-your-own-model setup &mdash; picks it up through MCP or the skill registry once configured. The agent then knows how to click, type, read the screen, open apps, and drive GUIs whenever the task requires it.
 
 ```
 User: "Open Outlook and reply to the latest email from Sarah."
@@ -89,9 +89,9 @@ clawdcursor grant     # Accessibility + Screen Recording
 curl -fsSL https://clawdcursor.com/install.sh | bash
 ```
 
-The installer drops the skill into `~/.clawdcursor`, registers an MCP server, and copies `SKILL.md` into every detected agent's skill directory (Claude Code, OpenClaw, Cursor). Nothing needs to run in the foreground &mdash; agents invoke the skill on demand through MCP stdio.
+The installer clones the skill into `~/clawdcursor`, runs `npm install`, builds, and registers a global `clawdcursor` shim via `npm link`. Runtime state (auth token, pidfiles, logs) lives at `~/.clawdcursor/`. To wire the skill into an agent host, follow [Connect Your Agent](#connect-your-agent) below &mdash; the installer does not edit any host config files automatically.
 
-> Linux notes: install `tesseract-ocr` for OCR, `at-spi2-core` + `python3-gi` for accessibility, and `ydotool` (or `wtype`) for Wayland input.
+> Linux notes: install `tesseract-ocr` for OCR, `python3-gi` + `gir1.2-atspi-2.0` for accessibility (the AT-SPI typelib `python3-gi` consumes), and `ydotool` (or `wtype`) for Wayland input.
 
 ---
 
@@ -101,7 +101,7 @@ The skill is transport-agnostic. Every agent below exposes the same tool catalog
 
 ### Claude Code
 
-Already done. The installer writes an MCP entry to `~/.claude/settings.json`. Claude Code picks up `clawdcursor` automatically on next start. If you are configuring it manually:
+Add the MCP entry to `~/.claude/settings.json` (the installer leaves agent host config untouched, so this step is required):
 
 ```jsonc
 // ~/.claude/settings.json
@@ -127,7 +127,7 @@ The skill metadata in [SKILL.md](SKILL.md) tells OpenClaw how to install, bootst
 
 Any MCP-aware editor. Add a stdio MCP entry pointing to `clawdcursor mcp --compact`. Refer to the host's MCP configuration docs.
 
-### Anthropic Agent SDK / bring-your-own-model
+### Claude Agent SDK / bring-your-own-model
 
 The skill also exposes a local REST surface for agents that do not speak MCP. Start the skill server once, then discover tools at `GET http://127.0.0.1:3847/tools?mode=compact` and call them at `POST /execute/:name`. Bearer-token auth; token written to `~/.clawdcursor/token`. See [API](#api) below.
 
@@ -141,13 +141,15 @@ The skill exposes two catalogs side by side. Agents pick the one that fits.
 
 Anthropic `computer_20250124`-style: one tool per capability, with an `action` enum for the verb. Small prompt footprint (~1,500 tokens), easy for a model to learn zero-shot, the default for most agents.
 
-| Tool | Actions |
+Most-used actions per compound below. The full enum is at `GET /tools?mode=compact` or via MCP `list_tools`.
+
+| Tool | Most-used actions |
 |---|---|
-| `computer` | `screenshot`, `click`, `double_click`, `right_click`, `hover`, `move_relative`, `scroll`, `drag`, `drag_path`, `type`, `key`, `wait` |
-| `accessibility` | `read_tree`, `find`, `get_element`, `focused`, `invoke`, `focus`, `set_value`, `get_value`, `expand`, `collapse`, `toggle`, `select`, `state`, `wait_for` |
-| `window` | `list`, `active`, `focus`, `maximize`, `minimize`, `restore`, `close`, `resize`, `open_app`, `open_file`, `open_url`, `navigate` |
+| `computer` | `screenshot`, `click`, `double_click`, `right_click`, `triple_click`, `hover`, `scroll`, `scroll_horizontal`, `drag`, `drag_path`, `type`, `key`, `wait` |
+| `accessibility` | `read_tree`, `find`, `get_element`, `focused`, `invoke`, `focus`, `set_value`, `get_value`, `expand`, `collapse`, `toggle`, `select`, `state`, `list_children`, `wait_for` |
+| `window` | `list`, `active`, `focus`, `maximize`, `minimize`, `restore`, `close`, `resize`, `list_displays`, `screen_size`, `open_app`, `open_file`, `open_url`, `switch_tab`, `navigate` |
 | `system` | `clipboard_read`, `clipboard_write`, `system_time`, `ocr`, `undo`, `shortcuts_list`, `shortcuts_run`, `delegate`, `detect_webview`, `relaunch_with_cdp` |
-| `browser` | `connect`, `read_text`, `click`, `type`, `select_option`, `evaluate`, `wait_for`, `list_tabs`, `switch_tab`, `scroll` |
+| `browser` | `connect`, `page_context`, `read_text`, `click`, `type`, `select_option`, `evaluate`, `wait_for`, `list_tabs`, `switch_tab`, `scroll` |
 | `task` | (no `action` enum &mdash; takes `{instruction: string}` and routes through the full pipeline) |
 
 ### Granular &mdash; 74 individual tools
@@ -159,9 +161,9 @@ Full catalog for agents that prefer one tool per verb. Sample of categories belo
 | Perception | `read_screen`, `desktop_screenshot`, `desktop_screenshot_region`, `ocr_read_screen`, `smart_read` |
 | Mouse | `mouse_click`, `mouse_double_click`, `mouse_drag`, `mouse_drag_stepped`, `mouse_scroll` |
 | Keyboard | `key_press`, `type_text`, `smart_type`, `shortcuts_list`, `shortcuts_execute` |
-| Window / App | `focus_window`, `open_app`, `get_windows`, `invoke_element`, `detect_webview_apps` |
+| Window / App | `focus_window`, `open_app`, `get_windows`, `get_active_window`, `detect_webview_apps` |
 | Browser (CDP) | `cdp_connect`, `cdp_click`, `cdp_type`, `cdp_read_text`, `cdp_evaluate` |
-| Accessibility | `find_element`, `wait_for_element`, `get_focused_element`, `a11y_expand`, `a11y_toggle` |
+| Accessibility | `find_element`, `invoke_element`, `wait_for_element`, `get_focused_element`, `a11y_expand`, `a11y_toggle` |
 | System | `read_clipboard`, `write_clipboard`, `get_system_time`, `undo_last`, `delegate_to_agent` |
 | Orchestration | `smart_click`, `navigate_browser`, `wait` |
 
@@ -249,7 +251,7 @@ Platform-specific code lives in `src/v2/platform/{windows,macos,linux}.ts` behin
 
 - **Node.js** 20 or newer
 - **macOS** &mdash; Xcode CLI tools (`xcode-select --install`), then `clawdcursor grant` for Accessibility + Screen Recording
-- **Linux** &mdash; `tesseract-ocr`, `at-spi2-core` + `python3-gi`, `ydotool` or `wtype` (Wayland)
+- **Linux** &mdash; `tesseract-ocr`, `python3-gi` + `gir1.2-atspi-2.0` (AT-SPI typelib), `ydotool` or `wtype` (Wayland)
 - **AI provider key** &mdash; configured on the agent side; the skill itself is model-agnostic
 
 ---
@@ -261,10 +263,14 @@ The CLI below is intended for humans diagnosing an install. Agents should not in
 ```
 clawdcursor doctor       Diagnose install, permissions, and platform bridges
 clawdcursor grant        Grant macOS permissions (interactive)
+clawdcursor consent      Manage desktop-control consent (--accept / --revoke / --status)
+clawdcursor status       Check readiness (consent, permissions, AI config)
 clawdcursor mcp          MCP stdio server (the primary skill transport)
 clawdcursor serve        REST-only tool server (bring-your-own-agent)
-clawdcursor dashboard    Open the web dashboard
 clawdcursor stop         Stop every running mode (mcp, serve, start)
+
+# The web dashboard is reachable at http://127.0.0.1:3847 while
+# `clawdcursor serve` (or `start`) is running — no separate command.
 
 # The two commands below exist for manual end-to-end testing only.
 # Real agents should not use these — they should call the skill through MCP.
@@ -272,7 +278,7 @@ clawdcursor start        Run the built-in autonomous agent (testing)
 clawdcursor task <t>     Send a task to that agent (testing)
 
 Options:
-  --port <port>          Default: 3847 (start, serve, stop, task, status)
+  --port <port>          Default: 3847 (start, serve, stop, task)
   --compact              MCP only: expose 6 compound tools instead of 74 granular.
                          For REST/serve, use the `?mode=compact` query parameter
                          on `GET /tools` instead.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Clawd Cursor</h1>
 
 <p align="center">
-  <strong>OS-level desktop automation server. Gives any AI model eyes, hands, and ears on a real computer.</strong><br>
-  Model-agnostic &middot; Works with Claude, GPT, Gemini, Llama, or any tool-calling model &middot; Free with local models
+  <strong>A desktop automation server for AI agents.</strong><br>
+  Gives any tool-calling model eyes, hands, and a keyboard on a real computer — Windows, macOS, Linux.
 </p>
 
 <p align="center">
@@ -21,97 +21,108 @@
   <a href="https://clawdcursor.com">Website</a> &middot;
   <a href="https://discord.gg/UGBWKvmj">Discord</a> &middot;
   <a href="#quick-start">Quick Start</a> &middot;
-  <a href="#connect">Connect</a> &middot;
+  <a href="#integration">Integration</a> &middot;
   <a href="#api">API</a> &middot;
   <a href="CHANGELOG.md">Changelog</a>
 </p>
 
 ---
 
-## What's New in v0.8.0 — V2 Architecture
+## Overview
 
-A vision-first alternative to the legacy cascade, opt in with `--v2`:
+Clawd Cursor is a local tool server that exposes the desktop — mouse, keyboard, screen, windows, accessibility tree, and browser — as a set of callable tools. Any model that can call functions can drive it.
 
-```bash
-clawdcursor start --v2
+```
+Your AI  →  "click the Send button"      →  find_element + mouse_click
+Your AI  →  "what's on screen?"          →  screenshot + read_screen
+Your AI  →  "open Chrome and go to gmail" →  open_app + navigate_browser
 ```
 
-- **Ground-truth verifier** — six independent signals (pixel diff, window state, focus change, OCR delta, task-type assertions, error-pattern detection). Independent of the agent, so it can't be fooled by "done" self-reports. Caught false positives in testing where the legacy pipeline reported `UNVERIFIED_SUCCESS`.
-- **Single vision-first agent loop** — screenshot → tool call → new screenshot → repeat. 6-rule system prompt (down from 36). Works with Anthropic, OpenAI, OpenRouter, or anything with vision + tool calls.
-- **PlatformAdapter abstraction** — platform-specific code now lives in `src/v2/platform/{macos,windows,linux}.ts` behind one interface. Replaces 142+ scattered `if (IS_MAC)` branches across 34 files. Adding a new OS is a single file.
-- **Legacy pipeline untouched** — `clawdcursor start` (no flag) behaves exactly as before. Zero breaking changes.
+No app-specific integrations, no per-service API keys, no cloud round-trip. If it renders on your screen, Clawd Cursor can read it and interact with it.
 
-Full history in [CHANGELOG.md](CHANGELOG.md).
+**Design goals:** model-agnostic (Claude, GPT, Gemini, local models), OS-agnostic (a single `PlatformAdapter` replaces every `if (process.platform)` branch in the codebase), and transport-agnostic (REST, MCP, or an autonomous built-in agent — same tools, same semantics).
 
 ---
 
-## What It Does
+## What's New in v0.8.4
 
-Clawd Cursor is a **tool server**. It wraps your desktop as 42 callable tools: mouse, keyboard, screen, windows, browser. Any AI that can call functions can use it.
+Security maintenance release. Patches every fixable CVE in the dependency tree:
 
-```
-Your AI → "Click the Send button"  →  find_element + mouse_click
-Your AI → "What's on screen?"      →  desktop_screenshot + read_screen
-Your AI → "Open Chrome to gmail"   →  open_app + navigate_browser
-```
+| Package | Severity | Issue |
+|---|---|---|
+| `vite` | High | Path traversal, `server.fs.deny` bypass, arbitrary read via WebSocket |
+| `path-to-regexp` | High | ReDoS via multiple route parameters |
+| `picomatch` | High | ReDoS + method injection in POSIX character classes |
+| `hono` | Moderate | HTML injection in `hono/jsx` SSR |
+| `follow-redirects` | Moderate | Auth headers leaked to cross-domain redirects |
 
-No app-specific integrations. No per-service API keys. If it's on screen, clawdcursor can interact with it.
+See [CHANGELOG.md](CHANGELOG.md) for the full v0.8.x history — unified blind/hybrid/vision pipeline (v0.8.2), compact MCP surface, Linux AT-SPI + Wayland support, Electron/WebView2 bridge, and session-reliability fixes.
 
 ---
 
 ## Quick Start
 
-**Windows**
+### Windows
+
 ```powershell
 powershell -c "irm https://clawdcursor.com/install.ps1 | iex"
 clawdcursor start
 ```
 
-**macOS**
+### macOS
+
 ```bash
 curl -fsSL https://clawdcursor.com/install.sh | bash
-clawdcursor grant     # grant Accessibility + Screen Recording permissions
+clawdcursor grant     # Accessibility + Screen Recording
 clawdcursor start
 ```
 
-**Linux**
+### Linux
+
 ```bash
 curl -fsSL https://clawdcursor.com/install.sh | bash
 clawdcursor start
 ```
 
-First run auto-detects your AI provider from environment variables. Or be explicit:
+The server auto-detects your provider from environment variables, or set it explicitly:
+
 ```bash
 clawdcursor start --provider anthropic --api-key sk-ant-...
-clawdcursor start --provider gemini     # GEMINI_API_KEY in env
-clawdcursor start                       # free with Ollama
+clawdcursor start --provider openai    # OPENAI_API_KEY
+clawdcursor start --provider ollama    # local, offline, free
 ```
 
-> See [docs/MACOS-SETUP.md](docs/MACOS-SETUP.md) for macOS permission setup.
+See [docs/MACOS-SETUP.md](docs/MACOS-SETUP.md) for macOS permission setup.
 
 ---
 
-## Connect
+## Integration
 
-Three modes. Same 42 tools.
+Three transports. Same tool catalog behind each.
 
-### 1. Built-in Agent (`start`)
-Full autonomous agent. Send a task, get a result.
+### 1. Autonomous agent &mdash; `clawdcursor start`
+
+Ships with a built-in agent. Send a plain-English task, get a result.
+
 ```bash
 clawdcursor start
-curl http://localhost:3847/task -d '{"task": "Open Notepad and write Hello"}'
+curl http://localhost:3847/task -d '{"task":"Open Notepad and write Hello"}'
 ```
 
-### 2. Tools-Only Server (`serve`)
-Exposes tools over REST. You bring the AI.
+### 2. Tool server &mdash; `clawdcursor serve`
+
+REST-only. Bring your own agent.
+
 ```bash
 clawdcursor serve
-curl http://localhost:3847/tools          # discover tools
+curl http://localhost:3847/tools                        # discover
 curl http://localhost:3847/execute/mouse_click -d '{"x":500,"y":300}'
 ```
 
-### 3. MCP Mode (`mcp`)
-MCP stdio server for Claude Code, Cursor, Windsurf, Zed.
+### 3. MCP server &mdash; `clawdcursor mcp`
+
+stdio MCP for Claude Code, Cursor, Windsurf, Zed, and any MCP-aware client.
+
 ```jsonc
 // ~/.claude/settings.json
 {
@@ -126,130 +137,160 @@ MCP stdio server for Claude Code, Cursor, Windsurf, Zed.
 
 ---
 
-## Tools
+## Tool Surface
 
-42 tools across 6 categories:
+Two tool catalogs are exposed side-by-side. Pick the one that fits your agent.
+
+### Compact (6 compound tools, recommended)
+
+Anthropic `computer_20250124`-style: one tool per capability, with an `action` enum for the verb. Small prompt footprint (~1,500 tokens), easy to learn, the default for most agents.
+
+| Tool | Actions |
+|---|---|
+| `computer` | `screenshot`, `click`, `type`, `key`, `scroll`, `drag`, `drag_path`, `wait` |
+| `accessibility` | `read_screen`, `find`, `get_focused`, `wait_for_element`, `invoke` |
+| `window` | `list`, `focus`, `set_state`, `set_bounds`, `get_active` |
+| `system` | `open_app`, `detect_webview`, `relaunch_with_cdp`, `read_clipboard`, `write_clipboard` |
+| `browser` | `connect`, `click`, `type`, `read_text`, `evaluate`, `navigate` |
+| `task` | `delegate`, `status`, `confirm`, `abort` |
+
+Activate with `clawdcursor mcp --compact` or `GET /tools?mode=compact`.
+
+### Granular (74 individual tools, power users)
+
+Full catalog for agents that prefer one tool per action. Grouped by capability:
 
 | Category | Count | Examples |
-|----------|-------|---------|
-| Perception | 9 | `desktop_screenshot`, `read_screen`, `get_active_window`, `smart_read`, `ocr_read_screen` |
-| Mouse | 6 | `mouse_click`, `mouse_double_click`, `mouse_drag`, `mouse_scroll` |
+|---|---|---|
+| Perception | 9 | `screenshot`, `read_screen`, `smart_read`, `ocr_read_screen`, `get_active_window` |
+| Mouse | 6 | `mouse_click`, `mouse_double_click`, `mouse_drag`, `mouse_drag_stepped`, `mouse_scroll` |
 | Keyboard | 5 | `key_press`, `type_text`, `smart_type`, `shortcuts_list`, `shortcuts_execute` |
-| Window / App | 6 | `focus_window`, `open_app`, `get_windows`, `invoke_element` |
+| Window / App | 8 | `focus_window`, `open_app`, `get_windows`, `invoke_element`, `detect_webview_apps` |
 | Browser (CDP) | 10 | `cdp_connect`, `cdp_click`, `cdp_type`, `cdp_read_text`, `cdp_evaluate` |
+| Accessibility | 6 | `get_ui_tree`, `find_elements`, `wait_for_element`, `get_focused_element` |
 | Orchestration | 6 | `smart_click`, `navigate_browser`, `delegate_to_agent`, `wait` |
+| &hellip; | &hellip; | &hellip; |
+
+Full catalog at `GET /tools` or `clawdcursor mcp`.
 
 ---
 
 ## Pipeline
 
-Two pipelines ship side by side. Same 42 tools, same MCP interface — only the decision-maker differs.
-
-### V2 — vision-first (`--v2`)
-
-Three stages, each does one thing:
+The built-in agent runs a unified blind/hybrid/vision loop. One agent, three modes, same tool catalog. The router picks the cheapest mode that can complete the task.
 
 ```
-┌──────────┐     ┌────────────────┐     ┌──────────────────────┐
-│  Router  │  →  │  VisionAgent   │  →  │  GroundTruthVerifier │
-│          │     │                │     │                      │
-│  regex   │     │  screenshot    │     │  pixel diff · window │
-│  shortcut│     │  → tool call   │     │  focus · OCR delta   │
-│  zero    │     │  → screenshot  │     │  task assertions     │
-│  LLM     │     │  → repeat      │     │  anti-patterns       │
-└──────────┘     └────────────────┘     └──────────────────────┘
+         ┌────────────────────────────────────────────┐
+task ──▶ │  Router   (regex shortcuts · zero LLM)    │ ──▶ done
+         └───────────────────┬────────────────────────┘
+                             │  (no match)
+                             ▼
+         ┌────────────────────────────────────────────┐
+         │  Blind     (accessibility tree only)       │ ──▶ done
+         └───────────────────┬────────────────────────┘
+                             │  (a11y sparse, stagnation)
+                             ▼
+         ┌────────────────────────────────────────────┐
+         │  Hybrid    (a11y + screenshot-on-demand)   │ ──▶ done
+         └───────────────────┬────────────────────────┘
+                             │  (still stuck)
+                             ▼
+         ┌────────────────────────────────────────────┐
+         │  Vision    (screenshot every turn)         │ ──▶ done
+         └────────────────────────────────────────────┘
 ```
 
-Router handles trivial tasks ("open Safari") without a model. Everything else hits the VisionAgent (16 tools, 6-rule prompt, model-agnostic). The Verifier runs six independent checks against the screen *after* the agent claims done — so "done" has to be true, not just asserted.
+Every tool call routes through a single `safety.evaluate()` chokepoint. The agent cannot bypass this path — it is the only way tools execute.
 
-### Legacy — text-first cascade (default, no flag)
+**Ground-truth verification.** On claims of completion, six independent signals are checked against the post-task screen: pixel diff, window-state change, focus change, OCR delta, task-type assertions (`send_email`, `navigate_url`, `open_app`, `type_text`, etc.), and anti-pattern detection (error dialogs, auth failures, "cannot send", "draft saved"). Weighted voting with hard-fail rules. The agent cannot self-report its way past the verifier.
 
-Cheapest-first. Kept for backwards compatibility.
-
-```
-L1.5   Deterministic flows  →  hardcoded sequences. Zero LLM.
-L2     Skill Cache          →  learned action patterns. Zero LLM.
-L2.5   OCR Reasoner         →  OS OCR + cheap text LLM. ~90% of tasks.
-L2.5b  A11y Reasoner        →  fallback when OCR is unavailable.
-L3     Computer Use         →  vision model. Last resort.
-```
+**Runaway guard.** If the agent calls the same tool with identical arguments three or more times in a six-turn window, the loop exits with a targeted diagnostic. Catches the common "retry because a11y is opaque" anti-pattern on Electron/WebView2 apps.
 
 ---
 
 ## API
 
-`http://localhost:3847`
+Base URL: `http://localhost:3847` (localhost-only, bearer-token auth)
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/tools` | GET | All tools in OpenAI function-calling format |
-| `/execute/:name` | POST | Execute a tool |
-| `/task` | POST | Submit a plain-English task |
-| `/status` | GET | Agent state |
-| `/screenshot` | GET | Current screen as PNG |
-| `/task-logs` | GET | Recent task logs (JSONL) |
-| `/confirm` | POST | Approve/reject a safety-gated action |
-| `/abort` | POST | Stop current task |
-| `/health` | GET | Version + health check |
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/tools` | GET | Full catalog in OpenAI function-calling format. `?mode=compact` for the 6-tool surface. |
+| `/execute/:name` | POST | Execute a tool by name. Returns structured JSON. |
+| `/task` | POST | Submit a plain-English task to the built-in agent. |
+| `/status` | GET | Current agent state and active task. |
+| `/screenshot` | GET | Current screen as PNG. |
+| `/task-logs` | GET | Recent task logs as JSONL. |
+| `/confirm` | POST | Approve or reject a safety-gated action. |
+| `/abort` | POST | Stop the current task. |
+| `/health` | GET | Version, uptime, and health check. |
 
 ---
 
 ## Safety
 
-| Tier | Actions | Behavior |
-|------|---------|----------|
-| Auto | Navigation, reading, opening apps | Runs immediately |
-| Preview | Typing, form filling | Logged before executing |
-| Confirm | Sending messages, deleting, purchases | Pauses for approval |
+Tools are classified into three tiers, enforced at the single `safety.evaluate()` chokepoint:
 
-Server binds to `localhost` only. Dangerous key combos blocked. Consent required on first run.
+| Tier | Actions | Behavior |
+|---|---|---|
+| Auto | Reading, navigation, opening apps | Executes immediately |
+| Preview | Typing, form fill, arbitrary input | Logged before executing |
+| Confirm | Sending messages, deleting, purchases | Pauses for user approval |
+
+Additional hardening: server binds to `localhost` only, bearer-token authentication on every request, dangerous key combinations (Cmd+Q, Alt+F4, Ctrl+Alt+Del) blocked by default, first-run consent prompt required.
 
 ---
 
 ## CLI
 
 ```
-clawdcursor start        Full agent (built-in LLM pipeline)
-clawdcursor serve        Tools-only REST server
+clawdcursor start        Autonomous agent (built-in LLM pipeline)
+clawdcursor serve        REST-only tool server
 clawdcursor mcp          MCP stdio server
-clawdcursor doctor       Diagnose and configure
+clawdcursor doctor       Diagnose install and configuration
 clawdcursor grant        Grant macOS permissions (interactive)
-clawdcursor task <t>     Send task to running agent
-clawdcursor stop         Stop server
-clawdcursor dashboard    Open web dashboard
+clawdcursor task <t>     Send a task to a running agent
+clawdcursor stop         Stop all running modes (start, serve, mcp)
+clawdcursor dashboard    Open the web dashboard
 
 Options:
   --port <port>          Default: 3847
-  --provider <name>      anthropic | openai | gemini | groq | ollama | deepseek | ...
-  --model <model>        Override model
-  --api-key <key>        Provider API key
+  --provider <name>      anthropic | openai | gemini | groq | ollama | deepseek | openrouter
+  --model <model>        Override the default model for the provider
+  --api-key <key>        Provider API key (else read from env)
   --base-url <url>       OpenAI-compatible endpoint
-  --accept               Skip consent prompt (non-interactive)
-  --v2                   Use v2 architecture (vision-first agent + ground truth verifier)
+  --compact              Expose compact 6-tool surface (MCP / serve)
+  --accept               Skip the consent prompt (non-interactive)
 ```
 
 ---
 
 ## Platform Support
 
-Platform-specific code lives in `src/v2/platform/{macos,windows,linux}.ts` behind one `PlatformAdapter` interface — business logic never reads `process.platform`.
+Platform-specific code lives in `src/v2/platform/{windows,macos,linux}.ts` behind a single `PlatformAdapter` interface. Business logic never reads `process.platform`.
 
 | Platform | UI Automation | OCR | Browser |
-|----------|---------------|-----|---------|
-| **Windows** x64 / ARM64 | PowerShell + UI Automation | Windows.Media.Ocr | Chrome / Edge |
-| **macOS** Intel / Apple Silicon | JXA + System Events | Apple Vision | Chrome / Edge |
-| **Linux** x64 / ARM64 | AT-SPI | Tesseract | Chrome / Edge |
+|---|---|---|---|
+| **Windows** x64 / ARM64 | UI Automation via PowerShell bridge | `Windows.Media.Ocr` | Chrome / Edge (CDP) |
+| **macOS** Intel / Apple Silicon | JXA + System Events (TCC-safe) | Apple Vision | Chrome / Edge (CDP) |
+| **Linux** X11 | AT-SPI + nut-js | Tesseract | Chrome / Edge (CDP) |
+| **Linux** Wayland | AT-SPI + `ydotool` / `wtype` | Tesseract | Chrome / Edge (CDP) |
+
+---
 
 ## Prerequisites
 
-- Node.js 20+
-- **macOS** — Xcode CLI tools: `xcode-select --install`, then `clawdcursor grant` for Accessibility + Screen Recording
-- **Linux** — `sudo apt install tesseract-ocr`
-- **AI key** — optional; works fully offline with Ollama
+- **Node.js** 20 or newer
+- **macOS** — Xcode CLI tools (`xcode-select --install`), then `clawdcursor grant` for Accessibility + Screen Recording
+- **Linux** — `tesseract-ocr` (OCR), `at-spi2-core` + `python3-gi` (accessibility), `ydotool` or `wtype` (Wayland input)
+- **AI provider key** — optional; works fully offline with Ollama
+
+---
 
 ## Tech Stack
 
-TypeScript · Node.js · nut-js · Playwright · sharp · Express · MCP SDK · Zod
+TypeScript · Node.js 20+ · nut-js · Playwright · sharp · Express · Hono · Model Context Protocol SDK · Zod
+
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Clawd Cursor</h1>
 
 <p align="center">
-  <strong>A desktop automation server for AI agents.</strong><br>
-  Gives any tool-calling model eyes, hands, and a keyboard on a real computer — Windows, macOS, Linux.
+  <strong>The skill that gives any AI agent eyes, hands, and a keyboard on a real desktop.</strong><br>
+  Install it. Your agent uses it. Windows, macOS, Linux &mdash; any tool-calling model.
 </p>
 
 <p align="center">
@@ -20,27 +20,35 @@
 <p align="center">
   <a href="https://clawdcursor.com">Website</a> &middot;
   <a href="https://discord.gg/UGBWKvmj">Discord</a> &middot;
-  <a href="#quick-start">Quick Start</a> &middot;
-  <a href="#integration">Integration</a> &middot;
-  <a href="#api">API</a> &middot;
+  <a href="#install-the-skill">Install</a> &middot;
+  <a href="#connect-your-agent">Connect</a> &middot;
+  <a href="#tool-surface">Tools</a> &middot;
   <a href="CHANGELOG.md">Changelog</a>
 </p>
 
 ---
 
-## Overview
+## What This Is
 
-Clawd Cursor is a local tool server that exposes the desktop — mouse, keyboard, screen, windows, accessibility tree, and browser — as a set of callable tools. Any model that can call functions can drive it.
+Clawd Cursor is a **skill**, not an application. It gives an AI agent the ability to use the user's computer &mdash; mouse, keyboard, screen, windows, browser &mdash; the same way a human would.
+
+You install it once. Any tool-calling agent on the machine &mdash; Claude Code, Cursor, Windsurf, OpenClaw, the Anthropic Agent SDK, or a bring-your-own-model setup &mdash; picks it up automatically through MCP or the skill registry. The agent then knows how to click, type, read the screen, open apps, and drive GUIs whenever the task requires it.
 
 ```
-Your AI  →  "click the Send button"      →  find_element + mouse_click
-Your AI  →  "what's on screen?"          →  screenshot + read_screen
-Your AI  →  "open Chrome and go to gmail" →  open_app + navigate_browser
+User: "Open Outlook and reply to the latest email from Sarah."
+
+Agent  →  system.open_app("Outlook")
+       →  accessibility.read_screen()
+       →  computer.click(sarah_email_row)
+       →  computer.key("Ctrl+R")
+       →  computer.type("...")
+       →  computer.click(send_button)
+       → done (verified by ground-truth verifier)
 ```
 
-No app-specific integrations, no per-service API keys, no cloud round-trip. If it renders on your screen, Clawd Cursor can read it and interact with it.
+No app-specific integrations. No per-service API keys. No cloud round-trip &mdash; everything runs locally on `127.0.0.1`. If it renders on screen, the agent can read it and act on it.
 
-**Design goals:** model-agnostic (Claude, GPT, Gemini, local models), OS-agnostic (a single `PlatformAdapter` replaces every `if (process.platform)` branch in the codebase), and transport-agnostic (REST, MCP, or an autonomous built-in agent — same tools, same semantics).
+**Design principles.** Model-agnostic (Claude, GPT, Gemini, local models via Ollama). OS-agnostic (a single `PlatformAdapter` handles Windows, macOS, and Linux behind one interface). Skill-first (the AI is the primary consumer; the CLI exists for testing).
 
 ---
 
@@ -56,17 +64,16 @@ Security maintenance release. Patches every fixable CVE in the dependency tree:
 | `hono` | Moderate | HTML injection in `hono/jsx` SSR |
 | `follow-redirects` | Moderate | Auth headers leaked to cross-domain redirects |
 
-See [CHANGELOG.md](CHANGELOG.md) for the full v0.8.x history — unified blind/hybrid/vision pipeline (v0.8.2), compact MCP surface, Linux AT-SPI + Wayland support, Electron/WebView2 bridge, and session-reliability fixes.
+See [CHANGELOG.md](CHANGELOG.md) for the full v0.8.x history &mdash; unified blind/hybrid/vision pipeline (v0.8.2), compact MCP surface, Linux AT-SPI + Wayland, Electron/WebView2 bridge, idempotent `open_app`, runaway guard.
 
 ---
 
-## Quick Start
+## Install the Skill
 
 ### Windows
 
 ```powershell
 powershell -c "irm https://clawdcursor.com/install.ps1 | iex"
-clawdcursor start
 ```
 
 ### macOS
@@ -74,76 +81,65 @@ clawdcursor start
 ```bash
 curl -fsSL https://clawdcursor.com/install.sh | bash
 clawdcursor grant     # Accessibility + Screen Recording
-clawdcursor start
 ```
 
 ### Linux
 
 ```bash
 curl -fsSL https://clawdcursor.com/install.sh | bash
-clawdcursor start
 ```
 
-The server auto-detects your provider from environment variables, or set it explicitly:
+The installer drops the skill into `~/.clawdcursor`, registers an MCP server, and copies `SKILL.md` into every detected agent's skill directory (Claude Code, OpenClaw, Cursor). Nothing needs to run in the foreground &mdash; agents invoke the skill on demand through MCP stdio.
 
-```bash
-clawdcursor start --provider anthropic --api-key sk-ant-...
-clawdcursor start --provider openai    # OPENAI_API_KEY
-clawdcursor start --provider ollama    # local, offline, free
-```
-
-See [docs/MACOS-SETUP.md](docs/MACOS-SETUP.md) for macOS permission setup.
+> Linux notes: install `tesseract-ocr` for OCR, `at-spi2-core` + `python3-gi` for accessibility, and `ydotool` (or `wtype`) for Wayland input.
 
 ---
 
-## Integration
+## Connect Your Agent
 
-Three transports. Same tool catalog behind each.
+The skill is transport-agnostic. Every agent below exposes the same tool catalog.
 
-### 1. Autonomous agent &mdash; `clawdcursor start`
+### Claude Code
 
-Ships with a built-in agent. Send a plain-English task, get a result.
-
-```bash
-clawdcursor start
-curl http://localhost:3847/task -d '{"task":"Open Notepad and write Hello"}'
-```
-
-### 2. Tool server &mdash; `clawdcursor serve`
-
-REST-only. Bring your own agent.
-
-```bash
-clawdcursor serve
-curl http://localhost:3847/tools                        # discover
-curl http://localhost:3847/execute/mouse_click -d '{"x":500,"y":300}'
-```
-
-### 3. MCP server &mdash; `clawdcursor mcp`
-
-stdio MCP for Claude Code, Cursor, Windsurf, Zed, and any MCP-aware client.
+Already done. The installer writes an MCP entry to `~/.claude/settings.json`. Claude Code picks up `clawdcursor` automatically on next start. If you are configuring it manually:
 
 ```jsonc
 // ~/.claude/settings.json
 {
   "mcpServers": {
     "clawdcursor": {
-      "command": "node",
-      "args": ["/path/to/clawdcursor/dist/index.js", "mcp"]
+      "command": "clawdcursor",
+      "args": ["mcp", "--compact"]
     }
   }
 }
 ```
 
+### OpenClaw
+
+```bash
+openclaw skill install clawdcursor
+```
+
+The skill metadata in [SKILL.md](SKILL.md) tells OpenClaw how to install, bootstrap, and discover the tool catalog. No further configuration needed.
+
+### Cursor, Windsurf, Zed
+
+Any MCP-aware editor. Add a stdio MCP entry pointing to `clawdcursor mcp --compact`. Refer to the host's MCP configuration docs.
+
+### Anthropic Agent SDK / bring-your-own-model
+
+The skill also exposes a local REST surface for agents that do not speak MCP. Start the skill server once, then discover tools at `GET http://127.0.0.1:3847/tools?mode=compact` and call them at `POST /execute/:name`. Bearer-token auth; token written to `~/.clawdcursor/token`. See [API](#api) below.
+
 ---
 
 ## Tool Surface
 
-Two tool catalogs are exposed side-by-side. Pick the one that fits your agent.
+The skill exposes two catalogs side by side. Agents pick the one that fits.
 
-### Compact (6 compound tools, recommended)
+### Compact &mdash; 6 compound tools (recommended)
 
-Anthropic `computer_20250124`-style: one tool per capability, with an `action` enum for the verb. Small prompt footprint (~1,500 tokens), easy to learn, the default for most agents.
+Anthropic `computer_20250124`-style: one tool per capability, with an `action` enum for the verb. Small prompt footprint (~1,500 tokens), easy for a model to learn zero-shot, the default for most agents.
 
 | Tool | Actions |
 |---|---|
@@ -154,75 +150,54 @@ Anthropic `computer_20250124`-style: one tool per capability, with an `action` e
 | `browser` | `connect`, `click`, `type`, `read_text`, `evaluate`, `navigate` |
 | `task` | `delegate`, `status`, `confirm`, `abort` |
 
-Activate with `clawdcursor mcp --compact` or `GET /tools?mode=compact`.
+### Granular &mdash; 74 individual tools
 
-### Granular (74 individual tools, power users)
-
-Full catalog for agents that prefer one tool per action. Grouped by capability:
+Full catalog for agents that prefer one tool per verb. Grouped by capability:
 
 | Category | Count | Examples |
 |---|---|---|
-| Perception | 9 | `screenshot`, `read_screen`, `smart_read`, `ocr_read_screen`, `get_active_window` |
+| Perception | 9 | `screenshot`, `read_screen`, `smart_read`, `ocr_read_screen` |
 | Mouse | 6 | `mouse_click`, `mouse_double_click`, `mouse_drag`, `mouse_drag_stepped`, `mouse_scroll` |
 | Keyboard | 5 | `key_press`, `type_text`, `smart_type`, `shortcuts_list`, `shortcuts_execute` |
 | Window / App | 8 | `focus_window`, `open_app`, `get_windows`, `invoke_element`, `detect_webview_apps` |
 | Browser (CDP) | 10 | `cdp_connect`, `cdp_click`, `cdp_type`, `cdp_read_text`, `cdp_evaluate` |
 | Accessibility | 6 | `get_ui_tree`, `find_elements`, `wait_for_element`, `get_focused_element` |
 | Orchestration | 6 | `smart_click`, `navigate_browser`, `delegate_to_agent`, `wait` |
-| &hellip; | &hellip; | &hellip; |
 
-Full catalog at `GET /tools` or `clawdcursor mcp`.
+Full catalog visible to the agent through MCP `list_tools` or at `GET /tools`.
 
 ---
 
-## Pipeline
+## How the Skill Thinks
 
-The built-in agent runs a unified blind/hybrid/vision loop. One agent, three modes, same tool catalog. The router picks the cheapest mode that can complete the task.
+Every tool call &mdash; whether it arrives over MCP, REST, or the built-in agent &mdash; passes through the same decision layer.
 
 ```
          ┌────────────────────────────────────────────┐
-task ──▶ │  Router   (regex shortcuts · zero LLM)    │ ──▶ done
+agent ─▶ │  Router   (regex shortcuts · zero LLM)    │ ──▶ tool
          └───────────────────┬────────────────────────┘
-                             │  (no match)
+                             │  (no shortcut match)
                              ▼
          ┌────────────────────────────────────────────┐
-         │  Blind     (accessibility tree only)       │ ──▶ done
+         │  Blind     (accessibility tree only)       │ ──▶ tool
          └───────────────────┬────────────────────────┘
                              │  (a11y sparse, stagnation)
                              ▼
          ┌────────────────────────────────────────────┐
-         │  Hybrid    (a11y + screenshot-on-demand)   │ ──▶ done
+         │  Hybrid    (a11y + screenshot-on-demand)   │ ──▶ tool
          └───────────────────┬────────────────────────┘
                              │  (still stuck)
                              ▼
          ┌────────────────────────────────────────────┐
-         │  Vision    (screenshot every turn)         │ ──▶ done
+         │  Vision    (screenshot every turn)         │ ──▶ tool
          └────────────────────────────────────────────┘
 ```
 
-Every tool call routes through a single `safety.evaluate()` chokepoint. The agent cannot bypass this path — it is the only way tools execute.
+Every tool call routes through a single `safety.evaluate()` chokepoint. The agent cannot bypass this path &mdash; it is the only way tools execute.
 
-**Ground-truth verification.** On claims of completion, six independent signals are checked against the post-task screen: pixel diff, window-state change, focus change, OCR delta, task-type assertions (`send_email`, `navigate_url`, `open_app`, `type_text`, etc.), and anti-pattern detection (error dialogs, auth failures, "cannot send", "draft saved"). Weighted voting with hard-fail rules. The agent cannot self-report its way past the verifier.
+**Ground-truth verification.** When a task is claimed complete, six independent signals are checked against the post-task screen: pixel diff, window-state change, focus change, OCR delta, task-type assertions (`send_email`, `navigate_url`, `open_app`, `type_text`, &hellip;), and anti-pattern detection (error dialogs, auth failures, "cannot send", "draft saved"). Weighted voting with hard-fail rules. The agent cannot self-report its way past the verifier.
 
-**Runaway guard.** If the agent calls the same tool with identical arguments three or more times in a six-turn window, the loop exits with a targeted diagnostic. Catches the common "retry because a11y is opaque" anti-pattern on Electron/WebView2 apps.
-
----
-
-## API
-
-Base URL: `http://localhost:3847` (localhost-only, bearer-token auth)
-
-| Endpoint | Method | Purpose |
-|---|---|---|
-| `/tools` | GET | Full catalog in OpenAI function-calling format. `?mode=compact` for the 6-tool surface. |
-| `/execute/:name` | POST | Execute a tool by name. Returns structured JSON. |
-| `/task` | POST | Submit a plain-English task to the built-in agent. |
-| `/status` | GET | Current agent state and active task. |
-| `/screenshot` | GET | Current screen as PNG. |
-| `/task-logs` | GET | Recent task logs as JSONL. |
-| `/confirm` | POST | Approve or reject a safety-gated action. |
-| `/abort` | POST | Stop the current task. |
-| `/health` | GET | Version, uptime, and health check. |
+**Runaway guard.** If the agent calls the same tool with identical arguments three or more times in a six-turn window, the loop exits with a targeted diagnostic &mdash; typically pointing at `detect_webview` when the target app is Electron/WebView2 with a sparse accessibility tree.
 
 ---
 
@@ -236,31 +211,23 @@ Tools are classified into three tiers, enforced at the single `safety.evaluate()
 | Preview | Typing, form fill, arbitrary input | Logged before executing |
 | Confirm | Sending messages, deleting, purchases | Pauses for user approval |
 
-Additional hardening: server binds to `localhost` only, bearer-token authentication on every request, dangerous key combinations (Cmd+Q, Alt+F4, Ctrl+Alt+Del) blocked by default, first-run consent prompt required.
+Hardening: server binds to `127.0.0.1` only, bearer-token auth on every request, dangerous key combinations (Cmd+Q, Alt+F4, Ctrl+Alt+Del) blocked by default, first-run consent prompt required. Sensitive categories (email, banking, password managers) require explicit user approval per action.
 
 ---
 
-## CLI
+## API
 
-```
-clawdcursor start        Autonomous agent (built-in LLM pipeline)
-clawdcursor serve        REST-only tool server
-clawdcursor mcp          MCP stdio server
-clawdcursor doctor       Diagnose install and configuration
-clawdcursor grant        Grant macOS permissions (interactive)
-clawdcursor task <t>     Send a task to a running agent
-clawdcursor stop         Stop all running modes (start, serve, mcp)
-clawdcursor dashboard    Open the web dashboard
+For agents that do not speak MCP. Base URL: `http://127.0.0.1:3847` (localhost-only, bearer-token auth, token at `~/.clawdcursor/token`).
 
-Options:
-  --port <port>          Default: 3847
-  --provider <name>      anthropic | openai | gemini | groq | ollama | deepseek | openrouter
-  --model <model>        Override the default model for the provider
-  --api-key <key>        Provider API key (else read from env)
-  --base-url <url>       OpenAI-compatible endpoint
-  --compact              Expose compact 6-tool surface (MCP / serve)
-  --accept               Skip the consent prompt (non-interactive)
-```
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/tools` | GET | Full catalog in OpenAI function-calling format. `?mode=compact` for the 6-tool surface. |
+| `/execute/:name` | POST | Execute a tool by name. Returns structured JSON. |
+| `/status` | GET | Current skill state. |
+| `/screenshot` | GET | Current screen as PNG. |
+| `/confirm` | POST | Approve or reject a safety-gated action. |
+| `/abort` | POST | Stop the in-flight task. |
+| `/health` | GET | Version, uptime, and health check. |
 
 ---
 
@@ -280,9 +247,35 @@ Platform-specific code lives in `src/v2/platform/{windows,macos,linux}.ts` behin
 ## Prerequisites
 
 - **Node.js** 20 or newer
-- **macOS** — Xcode CLI tools (`xcode-select --install`), then `clawdcursor grant` for Accessibility + Screen Recording
-- **Linux** — `tesseract-ocr` (OCR), `at-spi2-core` + `python3-gi` (accessibility), `ydotool` or `wtype` (Wayland input)
-- **AI provider key** — optional; works fully offline with Ollama
+- **macOS** &mdash; Xcode CLI tools (`xcode-select --install`), then `clawdcursor grant` for Accessibility + Screen Recording
+- **Linux** &mdash; `tesseract-ocr`, `at-spi2-core` + `python3-gi`, `ydotool` or `wtype` (Wayland)
+- **AI provider key** &mdash; configured on the agent side; the skill itself is model-agnostic
+
+---
+
+## Testing and Troubleshooting
+
+The CLI below is intended for humans diagnosing an install. Agents should not invoke it; they should use MCP or the REST surface.
+
+```
+clawdcursor doctor       Diagnose install, permissions, and platform bridges
+clawdcursor grant        Grant macOS permissions (interactive)
+clawdcursor mcp          MCP stdio server (the primary skill transport)
+clawdcursor serve        REST-only tool server (bring-your-own-agent)
+clawdcursor dashboard    Open the web dashboard
+clawdcursor stop         Stop every running mode (mcp, serve, start)
+
+# The two commands below exist for manual end-to-end testing only.
+# Real agents should not use these — they should call the skill through MCP.
+clawdcursor start        Run the built-in autonomous agent (testing)
+clawdcursor task <t>     Send a task to that agent (testing)
+
+Options:
+  --port <port>          Default: 3847
+  --compact              Expose compact 6-tool surface (MCP / serve)
+  --provider <name>      Only for `start`: anthropic | openai | gemini | ollama | ...
+  --accept               Skip the consent prompt (non-interactive)
+```
 
 ---
 
@@ -294,7 +287,7 @@ TypeScript · Node.js 20+ · nut-js · Playwright · sharp · Express · Hono ·
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT &mdash; see [LICENSE](LICENSE).
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdcursor
-version: 0.8.3
+version: 0.8.4
 description: >
   The skill that gives AI agents eyes, hands, and ears on a real desktop.
   When the user asks you to do something a human would normally do at their

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,6 +35,8 @@ metadata:
 
 **If a human can do it on a screen, you can too.** No API? No integration? No problem.
 
+> **No task is impossible.** If the user has a GUI, a mouse, and a keyboard — you have everything you need. There is no "I can't do that in this app." There is only the right sequence of reads, clicks, keys, and waits to get it done. Clawdcursor gives you all of them.
+
 > **USE AS A FALLBACK — NOT FIRST CHOICE**
 >
 > Before reaching for any clawdcursor tool, ask:
@@ -102,6 +104,17 @@ task({instruction})       See above — hand off a whole task to the pipeline
 Pick a compound FIRST based on what kind of operation it is, then set the
 `action` enum, then supply the args. The catalog is ~1,500 tokens — ~12× smaller
 than the granular surface — so small models (Haiku, Kimi, Ollama) stay focused.
+
+### Cost tier — always use the cheapest tier that works
+
+| Tier | Label | Cost | Use when |
+|---|---|---|---|
+| T1 | **structured** | ~free | Default. `accessibility.*`, `window.*`, `browser.read_text`, clipboard. Returns structured text — no image, no vision LLM. |
+| T2 | **ocr** | cheap | A11y tree is empty or sparse. `system({"action":"ocr"})` — OS-level OCR, text out, no LLM vision. |
+| T3 | **screenshot** | medium | OCR isn't enough and you need pixel context. `computer({"action":"screenshot"})` — sends an image into the LLM context. Use sparingly. |
+| T4 | **vision** | expensive | Screen is canvas-only (Paint, Figma, games) or the task requires spatial reasoning that text cannot express. `smart_click`, `smart_read`, `smart_type`. Last resort. |
+
+**Rule: start at T1. Escalate to the next tier only when the current one fails.** The pipeline does this automatically via `task({...})`; apply the same logic when you call compound tools manually.
 
 ### Quick reference — what action to pick
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdcursor
-version: 0.8.4
+version: 0.8.5
 description: >
   The skill that gives AI agents eyes, hands, and a keyboard on a real desktop.
   When the user asks you to do something a human would normally do at their
@@ -449,10 +449,14 @@ Per-OS setup notes:
 
 ---
 
+**What's new in 0.8.5:**
+- **Compact-tool keyboard fix** — `computer({"action":"key","combo":"mod+s"})` now actually works. The remap `combo → key` documented in `compact.ts` since v0.8.1 was never implemented; it is now wired up across `key`, `key_press`, `key_down`, and `key_up` actions.
+- **Cost-tier ladder** — added an explicit T1/T2/T3/T4 ladder to SKILL.md (structured a11y → OCR → screenshot → vision) so agents know to escalate cost only when the cheaper tier fails. Plus a "no task is impossible" callout: GUI + mouse + keyboard = everything you need.
+- **Documentation accuracy pass** — 16 review findings closed across README, SKILL.md, docs/index.html, and source comments: corrected installer claims (no MCP auto-register, no SKILL.md propagation, install path is `~/clawdcursor` not `~/.clawdcursor`); fixed compact-action enum names (`accessibility.read_tree` not `read_screen`, `system.clipboard_read` not `read_clipboard`, etc.); fixed Linux a11y package (`gir1.2-atspi-2.0`, not `at-spi2-core`); removed non-existent `clawdcursor dashboard` command; renamed "Anthropic Agent SDK" → "Claude Agent SDK"; aligned tool counts at 74 across all docs and source comments.
+
 **What's new in 0.8.4:**
 - **Dependency security audit** — patches every fixable advisory in the lockfile: vite (3× high — path traversal, fs.deny bypass, WS read), path-to-regexp (high — ReDoS), picomatch (high — ReDoS + method injection), hono (moderate — JSX SSR HTML injection), follow-redirects (moderate — auth-header leak across cross-domain redirects). 7 moderate alerts in the `jimp → @nut-tree-fork/nut-js` chain remain — no upstream fix yet.
 - **README rewrite** — reframed clawdcursor as a *skill* rather than a standalone server. The `start`/`task` CLI is now explicitly testing-only; agents reach the skill via MCP (`clawdcursor mcp --compact`) or the local REST surface (`clawdcursor serve`).
-- **Compact-tool fix** — `computer({"action":"key","combo":"mod+s"})` now actually works. The remap `combo → key` documented in `compact.ts` since v0.8.1 was never implemented; it is now wired up across `key`, `key_press`, `key_down`, and `key_up` actions.
 
 **What's new in 0.8.3:**
 - **Idempotent `open_app`** — repeated `open_app("Outlook")` calls focus the existing window instead of stacking new instances. Closes the "N copies of Outlook" class of bug under any retry loop.

--- a/SKILL.md
+++ b/SKILL.md
@@ -29,7 +29,6 @@ metadata:
     install:
       - npm install -g clawdcursor
       - clawdcursor consent --accept
-      - clawdcursor serve
     skill_dir: ~/.openclaw/workspace/skills/clawdcursor
 ---
 
@@ -246,7 +245,7 @@ All POST endpoints require `Authorization: Bearer <token>` — token at
 GET  /tools                  → 74 granular schemas (OpenAI function-calling)
 GET  /tools?mode=compact     → 6 compound schemas (recommended for LLMs)
 POST /execute/{name}         → run any tool by name — granular or compact
-GET  /health                 → {"status":"ok","version":"0.8.2"}
+GET  /health                 → {"status":"ok","version":"<x.y.z>"}
 GET  /docs                   → full docs for the granular surface
 GET  /docs?mode=compact      → docs for the compact surface
 ```
@@ -450,6 +449,16 @@ Per-OS setup notes:
 
 ---
 
+**What's new in 0.8.4:**
+- **Dependency security audit** — patches every fixable advisory in the lockfile: vite (3× high — path traversal, fs.deny bypass, WS read), path-to-regexp (high — ReDoS), picomatch (high — ReDoS + method injection), hono (moderate — JSX SSR HTML injection), follow-redirects (moderate — auth-header leak across cross-domain redirects). 7 moderate alerts in the `jimp → @nut-tree-fork/nut-js` chain remain — no upstream fix yet.
+- **README rewrite** — reframed clawdcursor as a *skill* rather than a standalone server. The `start`/`task` CLI is now explicitly testing-only; agents reach the skill via MCP (`clawdcursor mcp --compact`) or the local REST surface (`clawdcursor serve`).
+- **Compact-tool fix** — `computer({"action":"key","combo":"mod+s"})` now actually works. The remap `combo → key` documented in `compact.ts` since v0.8.1 was never implemented; it is now wired up across `key`, `key_press`, `key_down`, and `key_up` actions.
+
+**What's new in 0.8.3:**
+- **Idempotent `open_app`** — repeated `open_app("Outlook")` calls focus the existing window instead of stacking new instances. Closes the "N copies of Outlook" class of bug under any retry loop.
+- **Agent runaway guard** — if the agent calls the same tool with identical args ≥ 3 times in a 6-turn window, the loop exits with a `give_up` and a targeted hint (typically pointing at `detect_webview` for Electron/WebView2 targets with sparse a11y trees).
+- **`clawdcursor stop` sweeps every mode** — tears down `start`, `serve`, AND `mcp` (stdio) processes by walking `~/.clawdcursor/*.pid`. Fixes the "stale `serve` keeps receiving traffic" footgun.
+
 **What's new in 0.8.2:**
 - **Silent-401 auth bug fixed** — `requireAuth` now accepts the on-disk token with an mtime cache so concurrent clawdcursor processes no longer cause mid-session 401s.
 - **Force-focus-window** — Windows `focus_window` now uses the `AttachThreadInput` + `AllowSetForegroundWindow` + topmost-toggle sequence to raise windows across foreground lock.
@@ -459,3 +468,5 @@ Per-OS setup notes:
 - **SKILL.md polish** — harder push to compact mode, Escape-in-web-apps warning, a11y-empty troubleshooting split between Electron and true-canvas cases.
 
 **0.8.1 features (now stable in 0.8.2):** unified blind/hybrid/vision agent (one loop, three modes), compact MCP surface (`--compact`, 6 tools, ~1.5k tokens — Anthropic Computer-Use style), Linux AT-SPI bridge (read-only), Wayland input routing via `ydotool`/`wtype`, cross-OS PlatformAdapter verified on Windows 11 + macOS 14 + Ubuntu 24. Model-agnostic (Claude, GPT, Gemini, Llama, Kimi, Ollama) over REST or MCP.
+
+> See [CHANGELOG.md](CHANGELOG.md) for full v0.8.x history.

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 name: clawdcursor
 version: 0.8.4
 description: >
-  The skill that gives AI agents eyes, hands, and ears on a real desktop.
+  The skill that gives AI agents eyes, hands, and a keyboard on a real desktop.
   When the user asks you to do something a human would normally do at their
   computer — click a button, type in a field, read what is on screen, open
   an app, send an email through a GUI, fill out a form, drive a web page
@@ -68,7 +68,7 @@ metadata:
 > - MCP clients: add `"args": ["mcp", "--compact"]` to your config.
 > - REST clients: use `GET /tools?mode=compact` and `POST /execute/{compound}` with an `action` enum.
 >
-> Granular mode's 72 tools are kept for back-compat. Compact's 6 tools are ~12× smaller and reduce mis-tool-selection. Use granular only if your runtime MUST have every primitive as its own top-level schema.
+> Granular mode's 74 tools are kept for back-compat. Compact's 6 tools are ~12× smaller and reduce mis-tool-selection. Use granular only if your runtime MUST have every primitive as its own top-level schema.
 
 If you connect via MCP with `--compact`, or hit REST's compact mode, you get a
 single tool that takes the whole task:
@@ -197,9 +197,9 @@ Never self-approve actions on these surfaces. The safety layer elevates them to 
 
 | Mode | Command | Brain | Tools available |
 |------|---------|-------|-----------------|
-| `serve` | `clawdcursor serve` | **You** (REST client) | 72 granular + 6 compact via HTTP |
-| `mcp` | `clawdcursor mcp [--compact]` | **You** (MCP client) | 72 granular (default) or 6 compact (`--compact`) via stdio |
-| `start` | `clawdcursor start` | Built-in LLM pipeline | 72 granular + autonomous agent (submit a task, poll for completion) |
+| `serve` | `clawdcursor serve` | **You** (REST client) | 74 granular + 6 compact via HTTP |
+| `mcp` | `clawdcursor mcp [--compact]` | **You** (MCP client) | 74 granular (default) or 6 compact (`--compact`) via stdio |
+| `start` | `clawdcursor start` | Built-in LLM pipeline | 74 granular + autonomous agent (submit a task, poll for completion) |
 
 In `serve` and `mcp` modes: **you reason, clawdcursor acts.** There is no built-in LLM. You call tools, interpret results, decide next steps. In `start` mode: clawdcursor reasons AND acts — hand it a plain-English task and poll for completion.
 
@@ -221,7 +221,7 @@ In `serve` and `mcp` modes: **you reason, clawdcursor acts.** There is no built-
 }
 ```
 
-**Granular — 72 individual tools (power-user, back-compat, larger prompt budget):**
+**Granular — 74 individual tools (power-user, back-compat, larger prompt budget):**
 ```json
 {
   "mcpServers": {
@@ -243,7 +243,7 @@ All POST endpoints require `Authorization: Bearer <token>` — token at
 `~/.clawdcursor/token`.
 
 ```
-GET  /tools                  → 72 granular schemas (OpenAI function-calling)
+GET  /tools                  → 74 granular schemas (OpenAI function-calling)
 GET  /tools?mode=compact     → 6 compound schemas (recommended for LLMs)
 POST /execute/{name}         → run any tool by name — granular or compact
 GET  /health                 → {"status":"ok","version":"0.8.2"}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Clawd Cursor v0.8.3</title>
-  <meta name="description" content="Clawd Cursor v0.8.3: the skill that gives any AI agent eyes, hands, and ears on a real desktop. 74 granular tools OR 6 compact compound tools (Anthropic Computer-Use style). Blind-first unified pipeline. Windows, macOS, Linux (X11 + Wayland).">
-  <meta property="og:title" content="Clawd Cursor v0.8.3">
+  <title>Clawd Cursor v0.8.4</title>
+  <meta name="description" content="Clawd Cursor v0.8.4: the skill that gives any AI agent eyes, hands, and ears on a real desktop. 74 granular tools OR 6 compact compound tools (Anthropic Computer-Use style). Blind-first unified pipeline. Windows, macOS, Linux (X11 + Wayland).">
+  <meta property="og:title" content="Clawd Cursor v0.8.4">
   <meta property="og:description" content="Blind-first desktop automation. 74 tools via REST + MCP, or 6 compact compound tools (1 per 12, ~12× fewer tokens). Any AI model, any OS.">
 
   <meta property="og:type" content="website">
@@ -16,7 +16,7 @@
 
   <!--
     AGENT-READABLE SUMMARY
-    clawdcursor v0.8.3: the skill that gives any AI agent eyes, hands, and ears on a real desktop.
+    clawdcursor v0.8.4: the skill that gives any AI agent eyes, hands, and ears on a real desktop.
 
     Install: powershell -c "irm https://clawdcursor.com/install.ps1 | iex" (Windows)
              curl -fsSL https://clawdcursor.com/install.sh | bash (macOS/Linux)
@@ -328,7 +328,7 @@
 
   <!-- Hero -->
   <div class="hero">
-    <div class="hero-badge"><div class="pulse"></div> v0.8.3: blind-first · compact MCP · idempotent open_app · runaway guard</div>
+    <div class="hero-badge"><div class="pulse"></div> v0.8.4: blind-first · compact MCP · idempotent open_app · runaway guard</div>
     <h1>Give your AI agent<br><span class="gr">eyes and hands</span><br>on your desktop</h1>
     <p>Any tool-calling model. Any OS. <strong>74 granular tools or 6 compact compound tools</strong> (Anthropic Computer-Use style). Blind-first pipeline tries accessibility trees before pixels — ~12× cheaper per turn than vision-only agents.</p>
     <div class="hero-btns">
@@ -557,7 +557,7 @@
 </div>
 
 <footer>
-  <p>clawd<strong>cursor</strong> v0.8.3 · localhost only · MIT · <a href="https://clawdcursor.com">Home</a> · <a href="https://github.com/AmrDab/clawdcursor">GitHub</a> · <a href="https://discord.gg/UGBWKvmj">Discord</a></p>
+  <p>clawd<strong>cursor</strong> v0.8.4 · localhost only · MIT · <a href="https://clawdcursor.com">Home</a> · <a href="https://github.com/AmrDab/clawdcursor">GitHub</a> · <a href="https://discord.gg/UGBWKvmj">Discord</a></p>
 </footer>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Clawd Cursor v0.8.4</title>
-  <meta name="description" content="Clawd Cursor v0.8.4: the skill that gives any AI agent eyes, hands, and ears on a real desktop. 74 granular tools OR 6 compact compound tools (Anthropic Computer-Use style). Blind-first unified pipeline. Windows, macOS, Linux (X11 + Wayland).">
+  <meta name="description" content="Clawd Cursor v0.8.4: the skill that gives any AI agent eyes, hands, and a keyboard on a real desktop. 74 granular tools OR 6 compact compound tools (Anthropic Computer-Use style). Blind-first unified pipeline. Windows, macOS, Linux (X11 + Wayland).">
   <meta property="og:title" content="Clawd Cursor v0.8.4">
   <meta property="og:description" content="Blind-first desktop automation. 74 tools via REST + MCP, or 6 compact compound tools (1 per 12, ~12× fewer tokens). Any AI model, any OS.">
 
@@ -16,7 +16,7 @@
 
   <!--
     AGENT-READABLE SUMMARY
-    clawdcursor v0.8.4: the skill that gives any AI agent eyes, hands, and ears on a real desktop.
+    clawdcursor v0.8.4: the skill that gives any AI agent eyes, hands, and a keyboard on a real desktop.
 
     Install: powershell -c "irm https://clawdcursor.com/install.ps1 | iex" (Windows)
              curl -fsSL https://clawdcursor.com/install.sh | bash (macOS/Linux)
@@ -328,7 +328,7 @@
 
   <!-- Hero -->
   <div class="hero">
-    <div class="hero-badge"><div class="pulse"></div> v0.8.4: blind-first · compact MCP · idempotent open_app · runaway guard</div>
+    <div class="hero-badge"><div class="pulse"></div> v0.8.4: dependency security audit · vite / picomatch / path-to-regexp / hono CVE patches</div>
     <h1>Give your AI agent<br><span class="gr">eyes and hands</span><br>on your desktop</h1>
     <p>Any tool-calling model. Any OS. <strong>74 granular tools or 6 compact compound tools</strong> (Anthropic Computer-Use style). Blind-first pipeline tries accessibility trees before pixels — ~12× cheaper per turn than vision-only agents.</p>
     <div class="hero-btns">
@@ -523,23 +523,23 @@
     <div class="code-box" id="os-windows" style="display:block;">
       <div class="code-hd"><div class="dot r"></div><div class="dot y"></div><div class="dot g"></div><span>PowerShell</span></div>
       <pre><code><span class="c-cmd">powershell -c</span> <span class="c-string">"irm https://clawdcursor.com/install.ps1 | iex"</span>
-<span class="c-cmd">clawdcursor start</span> <span class="c-flag">--v2</span>  <span class="c-comment"># opt into vision-first v2 pipeline</span></code></pre>
+<span class="c-cmd">clawdcursor start</span></code></pre>
     </div>
 
     <div class="code-box" id="os-macos" style="display:none;">
       <div class="code-hd"><div class="dot r"></div><div class="dot y"></div><div class="dot g"></div><span>Terminal</span></div>
       <pre><code><span class="c-cmd">curl -fsSL</span> <span class="c-string">https://clawdcursor.com/install.sh</span> <span class="c-cmd">| bash</span>
 <span class="c-cmd">clawdcursor grant</span>  <span class="c-comment"># Accessibility + Screen Recording</span>
-<span class="c-cmd">clawdcursor start</span> <span class="c-flag">--v2</span></code></pre>
+<span class="c-cmd">clawdcursor start</span></code></pre>
     </div>
 
     <div class="code-box" id="os-linux" style="display:none;">
       <div class="code-hd"><div class="dot r"></div><div class="dot y"></div><div class="dot g"></div><span>Terminal</span></div>
       <pre><code><span class="c-cmd">curl -fsSL</span> <span class="c-string">https://clawdcursor.com/install.sh</span> <span class="c-cmd">| bash</span>
-<span class="c-cmd">clawdcursor start</span> <span class="c-flag">--v2</span></code></pre>
+<span class="c-cmd">clawdcursor start</span></code></pre>
     </div>
 
-    <p style="color:var(--text3);font-size:0.78rem;margin-top:10px;">Node.js 20+. Localhost only. Drop <code style="font-size:0.95em">--v2</code> to run the legacy pipeline.</p>
+    <p style="color:var(--text3);font-size:0.78rem;margin-top:10px;">Node.js 20+. Localhost only. The blind/hybrid/vision pipeline is unified — no flags needed.</p>
   </section>
 
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Clawd Cursor v0.8.4</title>
-  <meta name="description" content="Clawd Cursor v0.8.4: the skill that gives any AI agent eyes, hands, and a keyboard on a real desktop. 74 granular tools OR 6 compact compound tools (Anthropic Computer-Use style). Blind-first unified pipeline. Windows, macOS, Linux (X11 + Wayland).">
-  <meta property="og:title" content="Clawd Cursor v0.8.4">
+  <title>Clawd Cursor v0.8.5</title>
+  <meta name="description" content="Clawd Cursor v0.8.5: the skill that gives any AI agent eyes, hands, and a keyboard on a real desktop. 74 granular tools OR 6 compact compound tools (Anthropic Computer-Use style). Blind-first unified pipeline. Windows, macOS, Linux (X11 + Wayland).">
+  <meta property="og:title" content="Clawd Cursor v0.8.5">
   <meta property="og:description" content="Blind-first desktop automation. 74 tools via REST + MCP, or 6 compact compound tools (1 per 12, ~12× fewer tokens). Any AI model, any OS.">
 
   <meta property="og:type" content="website">
@@ -16,7 +16,7 @@
 
   <!--
     AGENT-READABLE SUMMARY
-    clawdcursor v0.8.4: the skill that gives any AI agent eyes, hands, and a keyboard on a real desktop.
+    clawdcursor v0.8.5: the skill that gives any AI agent eyes, hands, and a keyboard on a real desktop.
 
     Install: powershell -c "irm https://clawdcursor.com/install.ps1 | iex" (Windows)
              curl -fsSL https://clawdcursor.com/install.sh | bash (macOS/Linux)
@@ -328,7 +328,7 @@
 
   <!-- Hero -->
   <div class="hero">
-    <div class="hero-badge"><div class="pulse"></div> v0.8.4: dependency security audit · vite / picomatch / path-to-regexp / hono / follow-redirects CVE patches</div>
+    <div class="hero-badge"><div class="pulse"></div> v0.8.5: review-fix maintenance · keyboard `combo` arg fix · cost-tier ladder · 16 doc accuracy fixes</div>
     <h1>Give your AI agent<br><span class="gr">eyes and hands</span><br>on your desktop</h1>
     <p>Any tool-calling model. Any OS. <strong>74 granular tools or 6 compact compound tools</strong> (Anthropic Computer-Use style). Blind-first pipeline tries accessibility trees before pixels — ~12× cheaper per turn than vision-only agents.</p>
     <div class="hero-btns">
@@ -557,7 +557,7 @@
 </div>
 
 <footer>
-  <p>clawd<strong>cursor</strong> v0.8.4 · localhost only · MIT · <a href="https://clawdcursor.com">Home</a> · <a href="https://github.com/AmrDab/clawdcursor">GitHub</a> · <a href="https://discord.gg/UGBWKvmj">Discord</a></p>
+  <p>clawd<strong>cursor</strong> v0.8.5 · localhost only · MIT · <a href="https://clawdcursor.com">Home</a> · <a href="https://github.com/AmrDab/clawdcursor">GitHub</a> · <a href="https://discord.gg/UGBWKvmj">Discord</a></p>
 </footer>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -328,7 +328,7 @@
 
   <!-- Hero -->
   <div class="hero">
-    <div class="hero-badge"><div class="pulse"></div> v0.8.4: dependency security audit · vite / picomatch / path-to-regexp / hono CVE patches</div>
+    <div class="hero-badge"><div class="pulse"></div> v0.8.4: dependency security audit · vite / picomatch / path-to-regexp / hono / follow-redirects CVE patches</div>
     <h1>Give your AI agent<br><span class="gr">eyes and hands</span><br>on your desktop</h1>
     <p>Any tool-calling model. Any OS. <strong>74 granular tools or 6 compact compound tools</strong> (Anthropic Computer-Use style). Blind-first pipeline tries accessibility trees before pixels — ~12× cheaper per turn than vision-only agents.</p>
     <div class="hero-btns">
@@ -523,23 +523,23 @@
     <div class="code-box" id="os-windows" style="display:block;">
       <div class="code-hd"><div class="dot r"></div><div class="dot y"></div><div class="dot g"></div><span>PowerShell</span></div>
       <pre><code><span class="c-cmd">powershell -c</span> <span class="c-string">"irm https://clawdcursor.com/install.ps1 | iex"</span>
-<span class="c-cmd">clawdcursor start</span></code></pre>
+<span class="c-cmd">clawdcursor doctor</span>  <span class="c-comment"># verify install + wire into your agent (MCP)</span></code></pre>
     </div>
 
     <div class="code-box" id="os-macos" style="display:none;">
       <div class="code-hd"><div class="dot r"></div><div class="dot y"></div><div class="dot g"></div><span>Terminal</span></div>
       <pre><code><span class="c-cmd">curl -fsSL</span> <span class="c-string">https://clawdcursor.com/install.sh</span> <span class="c-cmd">| bash</span>
-<span class="c-cmd">clawdcursor grant</span>  <span class="c-comment"># Accessibility + Screen Recording</span>
-<span class="c-cmd">clawdcursor start</span></code></pre>
+<span class="c-cmd">clawdcursor grant</span>   <span class="c-comment"># Accessibility + Screen Recording</span>
+<span class="c-cmd">clawdcursor doctor</span>  <span class="c-comment"># verify install + wire into your agent (MCP)</span></code></pre>
     </div>
 
     <div class="code-box" id="os-linux" style="display:none;">
       <div class="code-hd"><div class="dot r"></div><div class="dot y"></div><div class="dot g"></div><span>Terminal</span></div>
       <pre><code><span class="c-cmd">curl -fsSL</span> <span class="c-string">https://clawdcursor.com/install.sh</span> <span class="c-cmd">| bash</span>
-<span class="c-cmd">clawdcursor start</span></code></pre>
+<span class="c-cmd">clawdcursor doctor</span>  <span class="c-comment"># verify install + wire into your agent (MCP)</span></code></pre>
     </div>
 
-    <p style="color:var(--text3);font-size:0.78rem;margin-top:10px;">Node.js 20+. Localhost only. The blind/hybrid/vision pipeline is unified — no flags needed.</p>
+    <p style="color:var(--text3);font-size:0.78rem;margin-top:10px;">Node.js 20+. Localhost only. clawdcursor is a <em>skill</em> — your agent calls it through MCP. <code style="font-size:0.95em">clawdcursor start</code> exists for manual testing only.</p>
   </section>
 
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawdcursor",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawdcursor",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawdcursor",
-  "version": "0.8.1-alpha.0",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawdcursor",
-      "version": "0.8.1-alpha.0",
+      "version": "0.8.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -4589,9 +4589,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4844,9 +4844,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5571,9 +5571,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -5617,9 +5617,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6663,9 +6663,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdcursor",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "The skill that gives any AI agent eyes, hands, and a keyboard on a real desktop. Model-agnostic — works with Claude, GPT, Gemini, Llama, or any tool-calling model — on Windows, macOS, and Linux.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdcursor",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "OS-level desktop automation server. Gives any AI model eyes, hands, and ears on a real computer. Model-agnostic — works with Claude, GPT, Gemini, Llama, or any tool-calling model.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clawdcursor",
   "version": "0.8.4",
-  "description": "OS-level desktop automation server. Gives any AI model eyes, hands, and ears on a real computer. Model-agnostic — works with Claude, GPT, Gemini, Llama, or any tool-calling model.",
+  "description": "The skill that gives any AI agent eyes, hands, and a keyboard on a real desktop. Model-agnostic — works with Claude, GPT, Gemini, Llama, or any tool-calling model — on Windows, macOS, and Linux.",
   "main": "dist/index.js",
   "bin": {
     "clawdcursor": "dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1010,7 +1010,7 @@ async function createToolContext() {
 program
   .command('mcp')
   .description('Run as MCP tool server over stdio (for Claude Code, Cursor, Windsurf, Zed)')
-  .option('--compact', 'Expose 6 compound tools instead of 72 granular ones (Anthropic Computer-Use style — recommended for most agents)')
+  .option('--compact', 'Expose 6 compound tools instead of 74 granular ones (Anthropic Computer-Use style — recommended for most agents)')
   .action(async (opts: { compact?: boolean }) => {
     // Single-instance guard (MCP servers can accumulate when editors restart them)
     const existingMcpPid = claimPidFile('mcp');
@@ -1054,7 +1054,7 @@ program
     const server = new McpServer({ name: 'clawdcursor', version: '0.7.2' });
 
     // Register tools. `--compact` ships the 6 compound tools that mirror
-    // Anthropic's computer_20250124 shape; default is the 72-tool granular
+    // Anthropic's computer_20250124 shape; default is the 74-tool granular
     // surface (back-compat for existing MCP wirings).
     const tools = opts.compact ? getCompactSurface() : getAllTools();
     for (const tool of tools) {

--- a/src/schema/snapshot.ts
+++ b/src/schema/snapshot.ts
@@ -48,11 +48,15 @@ export function snapshotPath(): string {
   return path.resolve(__dirname, '..', '..', 'schema.snapshot.json');
 }
 
-/** Read the stored snapshot; null if missing. */
+/** Read the stored snapshot; null if missing.
+ *  EOLs are normalized to LF so Windows autocrlf checkouts don't
+ *  cause spurious diffs against `currentSnapshot()` (which writes
+ *  literal '\n'). The .gitattributes rule is the primary fix; this
+ *  is defense-in-depth. */
 export function readStoredSnapshot(): string | null {
   const p = snapshotPath();
   if (!fs.existsSync(p)) return null;
-  return fs.readFileSync(p, 'utf8');
+  return fs.readFileSync(p, 'utf8').replace(/\r\n/g, '\n');
 }
 
 /** Write the current snapshot to the committed file. */

--- a/src/tool-server.ts
+++ b/src/tool-server.ts
@@ -71,7 +71,7 @@ export function createToolServer(ctx: ToolContext): express.Router {
 
   router.get('/tools', (_req, res) => {
     // `?mode=compact` → 6 compound tools (Anthropic Computer-Use style).
-    // Default   → 72 granular tools (back-compat, fine-grained control).
+    // Default   → 74 granular tools (back-compat, fine-grained control).
     const mode = _req.query.mode === 'compact' ? 'compact' : 'granular';
     const tools = mode === 'compact' ? getCompactSurface() : getAllTools();
     const format = _req.query.format as string;
@@ -154,8 +154,8 @@ export function createToolServer(ctx: ToolContext): express.Router {
     md += `**Two tool surfaces** are available over this server:\n\n`;
     md += `| Surface | Tools | Use when |\n`;
     md += `|---|---|---|\n`;
-    md += `| **Granular** (default) | 72 | You're writing code that calls individual primitives by name (\`mouse_click\`, \`type_text\`, …). |\n`;
-    md += `| **Compact** (\`?mode=compact\`) | 6 | You're an LLM agent. Collapses the 72 primitives into 6 compound tools with action enums — Anthropic Computer-Use style. ~12× fewer tool-catalog tokens. |\n\n`;
+    md += `| **Granular** (default) | 74 | You're writing code that calls individual primitives by name (\`mouse_click\`, \`type_text\`, …). |\n`;
+    md += `| **Compact** (\`?mode=compact\`) | 6 | You're an LLM agent. Collapses the 74 primitives into 6 compound tools with action enums — Anthropic Computer-Use style. ~12× fewer tool-catalog tokens. |\n\n`;
     md += `You are currently viewing the **${mode}** surface.\n\n`;
     md += `## Endpoints\n\n`;
     md += `- \`GET /tools\` — Granular schemas (OpenAI function format)\n`;

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -3,10 +3,10 @@
  * primitive, Anthropic-Computer-Use-style.
  *
  * Why this exists:
- *   An agent driving clawdcursor via MCP otherwise sees 72 granular
+ *   An agent driving clawdcursor via MCP otherwise sees 74 granular
  *   tool schemas (~18,000 tokens of tool catalog). Most models
  *   over-think the choice, pick near-duplicates, and burn context.
- *   This file collapses the 72 tools into 6 action-discriminated
+ *   This file collapses the 74 tools into 6 action-discriminated
  *   compound tools — the same "1 tool with N sub-actions" shape that
  *   Anthropic uses for computer_20250124.
  *
@@ -22,7 +22,7 @@
  * pick which shape to consume.
  *
  * Selection:
- *   `clawdcursor mcp`             → 72 granular tools (back-compat)
+ *   `clawdcursor mcp`             → 74 granular tools (back-compat)
  *   `clawdcursor mcp --compact`   → 6 compound tools (this file)
  *   GET /tools?mode=compact      → REST gets the same compact schemas
  *
@@ -71,12 +71,14 @@ const COMPUTER_ACTIONS: ActionRoute[] = [
   { action: 'drag_path',     delegate: 'mouse_drag_stepped', argRemap: { path: 'path' } },
   { action: 'mouse_down',    delegate: 'mouse_down' },
   { action: 'mouse_up',      delegate: 'mouse_up' },
-  // Keyboard
+  // Keyboard — `combo` is the natural compound name for a key chord;
+  // it remaps to the granular `key_press`'s `key` parameter (see argRemap
+  // doc-comment above).
   { action: 'type',      delegate: 'type_text' },
-  { action: 'key',       delegate: 'key_press' },
-  { action: 'key_press', delegate: 'key_press' },
-  { action: 'key_down',  delegate: 'key_down' },
-  { action: 'key_up',    delegate: 'key_up' },
+  { action: 'key',       delegate: 'key_press', argRemap: { combo: 'key' } },
+  { action: 'key_press', delegate: 'key_press', argRemap: { combo: 'key' } },
+  { action: 'key_down',  delegate: 'key_down',  argRemap: { combo: 'key' } },
+  { action: 'key_up',    delegate: 'key_up',    argRemap: { combo: 'key' } },
   // Flow
   { action: 'wait',      delegate: 'wait' },
 ];

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,7 +23,7 @@ export type { ToolDefinition, ToolContext, ToolResult };
 export { toOpenAiFunctions, toJsonSchema };
 export { getCompactTools };
 
-/** Get all registered GRANULAR tools (the 72-tool surface). */
+/** Get all registered GRANULAR tools (the 74-tool surface). */
 export function getAllTools(): ToolDefinition[] {
   return [
     ...getDesktopTools(),


### PR DESCRIPTION
## Summary

Two-release cycle: v0.8.4 (security maintenance + skill reframing) and v0.8.5 (review-fix maintenance, including one real behavior bug). Both tagged.

## v0.8.4 — security + skill reframe

- **Dependency security audit.** `npm audit fix` patches 5 of 12 advisories (all 3 high-severity): vite (path traversal, fs.deny bypass, WS read), path-to-regexp (ReDoS), picomatch (ReDoS + method injection), hono (JSX SSR HTML injection), follow-redirects (auth-header leak). Remaining 7 moderate alerts chain through `jimp → @nut-tree-fork/nut-js`; no upstream fix yet.
- **Skill-first README rewrite.** Headline now reads "The skill that gives any AI agent eyes, hands, and a keyboard on a real desktop." `clawdcursor start` / `task` demoted to a "Testing and Troubleshooting" appendix — agents reach the skill through MCP or the REST surface, not by running daemons.
- **Cost-tier ladder + "no task is impossible"** added to SKILL.md. T1 structured a11y → T2 OCR → T3 screenshot → T4 vision; agents start at T1 and escalate only when the cheaper tier fails.

## v0.8.5 — review-fix maintenance

Two rounds of remote review caught one real bug and a long tail of doc drift.

**Code:**
- `computer({"action":"key","combo":"..."})` now actually works. The compact `key` / `key_press` / `key_down` / `key_up` actions had no `argRemap`, so the schema exposed `key` (not `combo`); REST rejected it as unknown and MCP silently dropped it, crashing the granular handler with `(undefined).toLowerCase()`. Implemented the remap that `compact.ts:46-47` had documented as the canonical example since v0.8.1.
- Stale "72 granular tools" count bumped to 74 in `clawdcursor mcp --help`, the markdown returned by `GET /docs`, and four source comments. Schema snapshot is unaffected.

**Docs (16 fixes across two review passes):**
- Installer claims rewritten — installer does NOT register MCP servers, does NOT propagate SKILL.md, clones to `~/clawdcursor` (no dot — `~/.clawdcursor/` is runtime state only).
- Compact-action enum names corrected throughout against `src/tools/compact.ts`: `accessibility.read_tree` not `read_screen`, `system.clipboard_read` not `read_clipboard`, `window.open_app` not `system.open_app`, `task` has no action enum (just `{instruction}`), etc.
- Linux a11y package: `gir1.2-atspi-2.0` (not `at-spi2-core`) — the typelib `python3-gi` consumes.
- Removed non-existent `clawdcursor dashboard` command. Added `status` + `consent` subcommands (referenced in Options block but never introduced).
- `--compact` / `--accept` flag scopes corrected (`--compact` is mcp-only; `--accept` lives on `start` and `consent`).
- "Anthropic Agent SDK" → "Claude Agent SDK" (official product name).
- `invoke_element` recategorized from Window/App to Accessibility.
- `docs/index.html` post-install step changed from testing-only `start` to `doctor`. Hero badge CVE list now includes `follow-redirects`.
- SKILL.md `/health` example uses `<x.y.z>` placeholder so it stops drifting per release. "What's new" expanded to cover 0.8.5 + 0.8.4 + 0.8.3 + 0.8.2.
- Pre-existing fix while in the area: dropped blocking `clawdcursor serve` from `metadata.openclaw.install` (would hang the OpenClaw installer or leave a zombie daemon).

**Verified, not changed:** Cmd+Q is blocked. Review claimed otherwise; verified against `keys-blocklist.ts:24` + `safety/layer.ts:325-328` — both `combo` and `key` arg paths route through the SafetyLayer chokepoint.

## Test plan

- [ ] `npm run typecheck` clean
- [ ] `npm run test:ci` — 429/430 pass (one skipped, same as v0.8.3)
- [ ] `npm run test:mcp-schema-snapshot` — granular schema unchanged (compact schema lives in `getCompactTools()` which the snapshot doesn't cover)
- [ ] Smoke: `clawdcursor mcp --compact`, then call `computer({"action":"key","combo":"mod+s"})` — should succeed end-to-end
- [ ] `clawdcursor mcp --help` shows "74 granular ones"
- [ ] `curl http://127.0.0.1:3847/docs` returns "Granular (default) | 74"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
