### PR TITLE
chore: README refresh, issue/PR templates, CONTRIBUTING.md, dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Something is broken or behaving wrong
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        **Before filing:** if this is a security issue (privilege escalation, token theft, safety-layer bypass), please use [private vulnerability reporting](https://github.com/AmrDab/clawdcursor/security/advisories/new) instead — see [SECURITY.md](https://github.com/AmrDab/clawdcursor/blob/main/SECURITY.md).
+  - type: input
+    id: version
+    attributes:
+      label: clawdcursor version
+      description: Output of `clawdcursor --version`
+      placeholder: e.g. 0.8.6
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux (X11)
+        - Linux (Wayland)
+    validations:
+      required: true
+  - type: input
+    id: os_version
+    attributes:
+      label: OS version
+      placeholder: e.g. macOS 14.5, Windows 11 23H2, Ubuntu 24.04
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface
+      description: Which entry point did you hit the bug through?
+      options:
+        - MCP (granular, default)
+        - MCP (compact, --compact flag)
+        - REST (clawdcursor serve)
+        - Autonomous agent (clawdcursor start)
+        - Installer
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: agent
+    attributes:
+      label: Agent / model (if applicable)
+      placeholder: e.g. Claude Code with Sonnet 4.6, Cursor with GPT-4o, Ollama llama3
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+      description: Include error messages, screenshots, or recordings if useful.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce. If possible, the exact tool call (`computer({...})`, REST `curl`, etc.).
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Output from `CLAWD_LOG=debug clawdcursor ...` or relevant lines from `~/.clawdcursor/logs/`. Redact any tokens or personal info.
+      render: shell
+  - type: textarea
+    id: doctor
+    attributes:
+      label: clawdcursor doctor output
+      description: Paste the output of `clawdcursor doctor`.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/AmrDab/clawdcursor/security/advisories/new
+    about: Report privately via GitHub Security Advisories. See SECURITY.md for scope.
+  - name: Question / discussion
+    url: https://discord.gg/UGBWKvmj
+    about: Ask in the #clawdcursor channel on Discord.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest a new capability or improvement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What is the agent or user trying to do that doesn't work today, or works clumsily?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What would you like clawdcursor to do? If you have a specific tool name, action enum, or API shape in mind, include it.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing tools or workarounds you've already tried, and why they fall short.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Single OS (macOS only)
+        - Single OS (Windows only)
+        - Single OS (Linux only)
+        - Cross-platform
+        - Documentation / SKILL.md
+        - Installer / packaging
+        - Not sure
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- One paragraph: what changes and why. Link any related issues. -->
+
+## Changes
+
+<!-- Bullet list of the substantive changes. File paths welcome. -->
+
+## Test plan
+
+<!-- How did you verify this works? Tick what applies. -->
+
+- [ ] `npm run typecheck` clean
+- [ ] `npm run test:ci` passing (429/430 baseline; note any new skips)
+- [ ] `npm run test:mcp-schema-snapshot` &mdash; if you touched `src/tools/`, the snapshot diff is intentional and committed
+- [ ] Manual smoke on at least one OS (specify which: macOS / Windows / Linux)
+- [ ] If touching MCP or REST surface: verified the tool call you changed works end-to-end through that surface
+
+## Risk / scope
+
+<!-- Anything reviewers should pay extra attention to: cross-OS behavior, schema changes, anything that touches the SafetyLayer chokepoint. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      types:
+        patterns:
+          - "@types/*"
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+    ignore:
+      # @nut-tree-fork/nut-js pulls in jimp; the moderate advisories chain through
+      # there. Track upstream rather than chasing transitive dependabot noise.
+      - dependency-name: "jimp"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to Clawd Cursor
+
+Thanks for considering a contribution. Clawd Cursor is a small project with a single maintainer; the goal of this guide is to keep PRs and issues tractable, not to gate-keep.
+
+## Before you start
+
+- **Bugs:** open an issue first if it's not obviously trivial. The bug template is a one-pager — fill it in honestly so we can repro.
+- **Features:** open a feature-request issue before writing code. Some ideas (a new compact action, a new platform) need an architectural sketch first to avoid wasted effort.
+- **Security issues:** do not open a public issue or PR. Use [GitHub private vulnerability reporting](https://github.com/AmrDab/clawdcursor/security/advisories/new) — see [SECURITY.md](SECURITY.md) for scope and what to include.
+
+## Local development
+
+```sh
+git clone https://github.com/AmrDab/clawdcursor.git
+cd clawdcursor
+npm install
+npm run setup              # builds, links the global `clawdcursor` binary, builds native helpers on macOS
+```
+
+Useful scripts:
+
+| Command | What it does |
+|---|---|
+| `npm run dev` | `tsx watch src/index.ts` — rebuild on save |
+| `npm run typecheck` | `tsc --noEmit` — must be clean |
+| `npm run lint` | ESLint over `src/` |
+| `npm run test` | `vitest` watch mode |
+| `npm run test:ci` | `vitest run` — 429/430 baseline, one intentional skip |
+| `npm run test:mcp-schema-snapshot` | Diffs the granular tool catalog against `schema.snapshot.json`. Fails if the schema changed. Commit the new snapshot (`:update`) when the change is intentional. |
+
+CI runs typecheck + lint + tests + schema snapshot on every PR across Windows, macOS, and Linux on Node 20 and 22. Match that locally before pushing where possible.
+
+## Code style
+
+- TypeScript strict mode is on. No `any` unless you have a real reason and a comment explaining it.
+- Business logic does not see `process.platform`. Cross-OS branches live in `src/v2/platform/{macos,windows,linux}.ts` behind the `PlatformAdapter` interface. If you find yourself writing `if (IS_MAC)` outside `src/v2/platform/`, move it.
+- Every tool call goes through the SafetyLayer (`src/pipeline/safety/layer.ts`). Do not add a tool that bypasses it. Destructive verbs (send, delete, close_window, blocked keyboard combos) must escalate to confirm.
+- New compact tool actions: define them in `src/tools/compact.ts`, then run `npm run test:mcp-schema-snapshot:update` and commit the snapshot diff. The `argRemap` field is how you alias agent-friendly arg names onto granular tools — see the `key`/`combo` example.
+- Tests live next to the code they test under `tests/`. Vitest. Prefer integration tests that hit the real adapter over mocks.
+
+## Commit messages
+
+Conventional-commits-ish. Lowercase type, colon, short imperative. Examples:
+
+```
+fix(safety): close-window confirm prompt now renders on Wayland
+feat(compact): add browser({"action":"page_context"})
+docs(readme): correct compact-action enum names
+release(0.8.7): two-line summary
+```
+
+The "what's new" line in CHANGELOG and SKILL.md gets edited too — small features can usually share a CHANGELOG entry with related work.
+
+## Pull requests
+
+- Use the PR template. The "Test plan" section matters — reviewers should not have to guess what you ran.
+- Include CHANGELOG.md and SKILL.md updates in the same PR as the code change. They are part of the surface area.
+- Schema snapshot diffs (`schema.snapshot.json`) must be intentional. If your PR shows a snapshot diff you did not expect, something else changed.
+- Cross-OS PRs: if you can't test on all three, say so. CI catches most cross-OS regressions but not all (Wayland and TCC permissions need real machines).
+
+## What gets merged
+
+Things I'll merge quickly: bug fixes with a clear repro, doc fixes, small PRs that make existing behavior more correct. Things that take longer to land: new tools (need schema review), changes to the SafetyLayer (need threat-model review), anything that adds a top-level dependency.
+
+If you've put work into a PR and it's been sitting more than a week, ping the issue or Discord — I have probably just lost track.

--- a/README.md
+++ b/README.md
@@ -52,19 +52,19 @@ No app-specific integrations. No per-service API keys. No cloud round-trip &mdas
 
 ---
 
-## What's New in v0.8.4
+## Latest Release
 
-Security maintenance release. Patches every fixable CVE in the dependency tree:
+**v0.8.6** &mdash; polish release. Fixes a stale `McpServer` version string that had been advertising `v0.7.2` in MCP client metadata since the v0.7.x line; adds `SECURITY.md` and a private vulnerability reporting channel; trims the homepage; prunes stale repo artifacts.
 
-| Package | Severity | Issue |
-|---|---|---|
-| `vite` | High | Path traversal, `server.fs.deny` bypass, arbitrary read via WebSocket |
-| `path-to-regexp` | High | ReDoS via multiple route parameters |
-| `picomatch` | High | ReDoS + method injection in POSIX character classes |
-| `hono` | Moderate | HTML injection in `hono/jsx` SSR |
-| `follow-redirects` | Moderate | Auth headers leaked to cross-domain redirects |
+The substantive work landed earlier in the v0.8.x line:
 
-See [CHANGELOG.md](CHANGELOG.md) for the full v0.8.x history &mdash; unified blind/hybrid/vision pipeline (v0.8.2), compact MCP surface, Linux AT-SPI + Wayland, Electron/WebView2 bridge, idempotent `open_app`, runaway guard.
+- **v0.8.5** &mdash; `computer({"action":"key","combo":"..."})` now actually works (compact-tool keyboard remap was missing); 16 documentation accuracy fixes; cost-tier ladder added to SKILL.md.
+- **v0.8.4** &mdash; security maintenance: patches every fixable CVE in the dependency tree (vite, path-to-regexp, picomatch, hono, follow-redirects); README rewritten to frame clawdcursor as a *skill* rather than a standalone server.
+- **v0.8.3** &mdash; idempotent `open_app` (no more N copies of Outlook stacking up under retry), agent runaway guard, `clawdcursor stop` sweeps every mode.
+- **v0.8.2** &mdash; silent-401 auth bug fixed, force-focus on Windows through the foreground lock, Electron/WebView2 detection + CDP relaunch hint.
+- **v0.8.1 (rolled into 0.8.2)** &mdash; unified blind/hybrid/vision pipeline (one loop, three strategy modes), compact MCP surface (6 tools, ~12&times; smaller catalog), Linux AT-SPI bridge, Wayland input routing.
+
+Full per-release detail in [CHANGELOG.md](CHANGELOG.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to v0.8.6 covering README + .github/ hygiene gaps. No source code changes, no version bump.

## Changes

- **README.md** — replaced the stale `## What's New in v0.8.4` section (we're at v0.8.6 now and that section had been carrying a v0.8.4 CVE table) with an evergreen `## Latest Release` block: leads with v0.8.6, summarizes the substantive 0.8.x line in five bullets (0.8.5/0.8.4/0.8.3/0.8.2/0.8.1-rolled-into-0.8.2), points at CHANGELOG.md for full detail. Stops needing per-release surgery.
- **.github/ISSUE_TEMPLATE/** — typed bug-report and feature-request templates. `config.yml` disables blank issues and routes security reporters at the private advisory flow (per `SECURITY.md` from #58) and questions at Discord. Bug template captures version / OS / surface / agent / repro / logs / `doctor` output up front so triage doesn't need a follow-up roundtrip.
- **.github/PULL_REQUEST_TEMPLATE.md** — Summary / Changes / Test plan / Risk. Test-plan checkboxes match `npm run typecheck` / `test:ci` / `test:mcp-schema-snapshot` and prompt for the OS the contributor smoke-tested on.
- **.github/dependabot.yml** — weekly npm + monthly github-actions updates. Groups `@types/*` and the eslint family so they don't each open separate PRs. Explicitly ignores `jimp` since the moderate advisories chain through `@nut-tree-fork/nut-js → jimp` and have no upstream fix yet — that one's tracked separately. Should auto-resolve the 2 moderate vulns GitHub keeps flagging on push, or at least open visible PRs for them.
- **CONTRIBUTING.md** — dev setup, scripts table, code-style invariants (PlatformAdapter, SafetyLayer chokepoint, schema-snapshot flow), commit conventions, "what gets merged" guidance.

## Test plan

- [ ] CI green (typecheck/lint/tests/schema unaffected — no source changes)
- [ ] Issue templates render correctly when opening a new issue from the GitHub UI
- [ ] Dependabot opens its first PR within a week (Monday cadence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)