### PR TITLE
chore: single-source the version string + CI guard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 <!-- How did you verify this works? Tick what applies. -->
 
 - [ ] `npm run typecheck` clean
-- [ ] `npm run test:ci` passing (429/430 baseline; note any new skips)
+- [ ] `npm run test:ci` passing (430/431 baseline; note any new skips)
 - [ ] `npm run test:mcp-schema-snapshot` &mdash; if you touched `src/tools/`, the snapshot diff is intentional and committed
 - [ ] Manual smoke on at least one OS (specify which: macOS / Windows / Linux)
 - [ ] If touching MCP or REST surface: verified the tool call you changed works end-to-end through that surface

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Useful scripts:
 | `npm run typecheck` | `tsc --noEmit` — must be clean |
 | `npm run lint` | ESLint over `src/` |
 | `npm run test` | `vitest` watch mode |
-| `npm run test:ci` | `vitest run` — 429/430 baseline, one intentional skip |
+| `npm run test:ci` | `vitest run` — 430/431 baseline, one intentional skip |
 | `npm run test:mcp-schema-snapshot` | Diffs the granular tool catalog against `schema.snapshot.json`. Fails if the schema changed. Commit the new snapshot (`:update`) when the change is intentional. |
 
 CI runs typecheck + lint + tests + schema snapshot on every PR across Windows, macOS, and Linux on Node 20 and 22. Match that locally before pushing where possible.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1051,7 +1051,7 @@ program
     const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js' as any);
     const { z } = await import('zod');
 
-    const server = new McpServer({ name: 'clawdcursor', version: '0.8.6' });
+    const server = new McpServer({ name: 'clawdcursor', version: VERSION });
 
     // Register tools. `--compact` ships the 6 compound tools that mirror
     // Anthropic's computer_20250124 shape; default is the 74-tool granular

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as readline from 'readline';
+import { VERSION } from './version';
 
 const CONSENT_DIR = path.join(os.homedir(), '.clawdcursor');
 const CONSENT_FILE = path.join(CONSENT_DIR, 'consent');
@@ -28,7 +29,7 @@ function saveConsent(): void {
     accepted: true,
     timestamp: new Date().toISOString(),
     platform: process.platform,
-    version: '0.8.6',
+    version: VERSION,
   }, null, 2));
 }
 

--- a/tests/version-drift.test.ts
+++ b/tests/version-drift.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+// Single-source-of-truth guard. The McpServer constructor and onboarding
+// consent file each had their own hardcoded version string for multiple
+// releases (the v0.8.6 release shipped specifically to flush the drift).
+// This test fails the build if any .ts under src/ pins package.json's
+// current version as a literal — the helper at src/version.ts is the
+// only allowed home for that string.
+
+const ROOT = join(__dirname, '..');
+const SRC = join(ROOT, 'src');
+const ALLOW = new Set([join(SRC, 'version.ts')]);
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (p.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+describe('version drift guard', () => {
+  it('no .ts file under src/ hardcodes the package.json version', () => {
+    const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')) as { version: string };
+    const needle = pkg.version;
+    const offenders: string[] = [];
+    for (const file of walk(SRC)) {
+      if (ALLOW.has(file)) continue;
+      const text = readFileSync(file, 'utf-8');
+      if (text.includes(`'${needle}'`) || text.includes(`"${needle}"`)) {
+        offenders.push(file.slice(ROOT.length + 1));
+      }
+    }
+    expect(offenders, `Hardcoded version "${needle}" found. Import VERSION from './version' instead.`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The McpServer constructor in `src/index.ts` and the consent file written by `src/onboarding.ts` each kept their own hardcoded copy of `package.json`'s version. Both drifted — `index.ts` shipped `0.7.2` in the MCP handshake for the entire v0.7.x → v0.8.5 run, and v0.8.6 was the release that flushed it. Same class of bug can recur on the next bump.

This closes the loop: both call sites now import `VERSION` from `src/version.ts` (which already reads `package.json` at runtime), and a new test fails the build if anyone reintroduces a literal version string under `src/`.

## Changes

- `src/index.ts:1054` — `version: '0.8.6'` → `version: VERSION` (already imported on line 52)
- `src/onboarding.ts` — import `VERSION`, replace hardcoded `'0.8.6'` in the consent payload
- `tests/version-drift.test.ts` — scans `src/**/*.ts` for the literal `package.json` version. Allowlist is exactly `src/version.ts`. Fails with the offending file paths if found
- `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md` — bump documented baseline 429/430 → 430/431 (+1 test)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test:ci` — 430 passed, 1 skipped (29 files, ~20s)
- [x] New test exercised: confirmed the suite includes `tests/version-drift.test.ts`
- [x] No schema changes — `src/tools/` untouched

## Risk / scope

Tiny blast radius. The MCP version field is informational (clients log it; no tooling switches on it). `VERSION` was already used in `src/server.ts`, `src/dashboard.ts`, `src/tool-server.ts`, and `src/report.ts` — this just brings the last two stragglers in line with the existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)