### PR TITLE
docs(skill): add OS scripting (AppleScript/COM/D-Bus) to fallback hierarchy

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -41,8 +41,9 @@ metadata:
 > Before reaching for any clawdcursor tool, ask:
 > 1. Is there a native API? (Gmail API, GitHub API, Slack API, Stripe API) → **use the API.**
 > 2. Is there a CLI? (`git`, `gh`, `aws`, `npm`, `curl`) → **use the CLI.**
-> 3. Can you edit the file directly? → **do that.**
-> 4. Is there a browser automation already wired up (Playwright, Puppeteer) for this exact site? → **use that.**
+> 3. Does the host OS expose a scripting interface for the target app? On macOS, `osascript` drives any app with a scripting dictionary (Mail, Notes, Reminders, Calendar, Messages, Music, Finder, Safari, Pages); on Windows, PowerShell + COM drives Office (`New-Object -ComObject Outlook.Application`) and most ActiveX-aware apps; on Linux, `gdbus` / `dbus-send` reaches Thunderbird, Evolution, and most GNOME apps. → **script it.** It uses the app's stored credentials, runs in microseconds, and never breaks when the toolbar moves.
+> 4. Can you edit the file directly? → **do that.**
+> 5. Is there a browser automation already wired up (Playwright, Puppeteer) for this exact site? → **use that.**
 >
 > **None of the above work? Now use clawdcursor.** It's for the last mile.
 
@@ -54,7 +55,7 @@ metadata:
 > 3. You **CAN** drive browsers, native apps, and system settings.
 > 4. You **MUST** respect safety tiers — Auto runs freely, Confirm requires user approval.
 > 5. You **MUST** ask the user before touching email, banking, messaging, or password managers.
-> 6. You **SHOULD** prefer direct tools (API, CLI, file edit) over GUI automation when available.
+> 6. You **SHOULD** prefer direct tools (API, CLI, OS scripting, file edit) over GUI automation when available.
 >
 > clawdcursor is your hands and eyes on the user's computer — used with their permission.
 
@@ -171,12 +172,16 @@ Pick clawdcursor when the task requires eyes and hands on a real desktop. Concre
 
 1. Is there a native API? (Gmail API, GitHub API, Slack API, Stripe API) → **use the API.**
 2. Is there a CLI? (`git`, `gh`, `aws`, `npm`, `curl`, `sqlite3`) → **use the CLI.**
-3. Can you edit the file directly on disk? → **do that.**
-4. Is there a browser automation already wired up (Playwright, Puppeteer) for this exact site? → **use that.**
+3. Does the host OS expose a scripting interface for the target app? → **script it.** A 5-line `osascript` (macOS), PowerShell COM call (Windows), or `gdbus` invocation (Linux) is faster, more reliable, and uses the app's own stored credentials — no clicking, no vision, no token exchange.
+   - **macOS** — `osascript -e 'tell application "Mail" to send …'` works for any app with a scripting dictionary: Mail, Notes, Reminders, Calendar, Messages, Music, Finder, Safari, Pages, Keynote, Numbers, Terminal, iTerm. Also reachable via JXA (`osascript -l JavaScript`).
+   - **Windows** — `New-Object -ComObject Outlook.Application` (and equivalents for Word, Excel, PowerPoint, IE/Edge) covers almost the entire Office and ActiveX ecosystem. UIAutomation via PowerShell's `System.Windows.Automation` for everything else.
+   - **Linux** — `gdbus call` / `dbus-send` reaches Thunderbird, Evolution, Nautilus, and most GNOME-stack apps. KDE apps expose D-Bus interfaces by default.
+4. Can you edit the file directly on disk? → **do that.**
+5. Is there a browser automation already wired up (Playwright, Puppeteer) for this exact site? → **use that.**
 
 If and only if none of those apply, use clawdcursor. It's the last mile.
 
-In OpenClaw terminology: clawdcursor is a **skill** (packaged workflow) that ultimately dispatches to **tools** (primitive API / CLI / GUI ops). Route API / CLI / file-edit tools first; reach for clawdcursor when only the GUI surface remains.
+In OpenClaw terminology: clawdcursor is a **skill** (packaged workflow) that ultimately dispatches to **tools** (primitive API / CLI / OS-script / GUI ops). Route API / CLI / scripting / file-edit tools first; reach for clawdcursor when only the GUI surface remains.
 
 ### ⚠️ Sensitive App Policy
 


### PR DESCRIPTION
## Summary

The existing **USE AS A FALLBACK** callout in `SKILL.md` lists APIs, CLIs, file edits, and browser automation as things to try before reaching for clawdcursor — but never the host OS's *scripting interfaces*. An agent that reads the checklist literally will skip past `osascript -e 'tell application "Mail" to send …'` and go straight to clicking pixels. That's slower, more brittle, and unnecessary when the target app already has a scripting dictionary.

This PR adds an **OS scripting tier** to the existing fallback hierarchy in two places:

1. The top-of-file callout (lines 39–47) — gets a new step 3 between "CLI" and "file edit."
2. The "When NOT to use this skill" section (lines 168–179) — same step, plus an expanded sub-list with per-OS pointers (macOS `osascript` / JXA, Windows PowerShell + COM, Linux `gdbus` / `dbus-send`).

Plus a one-word fix to the SHOULD-prefer-direct-tools line so it lists `OS scripting` alongside API / CLI / file edit.

## Why now

A live test demoed the gap: sending an email via Mail.app on macOS is a **5-line `osascript` heredoc** that uses Mail's already-stored Google OAuth token. Clean, instant, no clicking. clawdcursor's existing `mac-mail-send` playbook does the same thing as a brittle keyboard choreography (`Cmd+N → Tab → Tab → … → Cmd+Shift+D`). Documenting the scripting tier — not engineering it — is the smaller, more honest fix: the agent already has shell access, it just didn't know to look there first.

## What this is NOT

- **Not a code change.** Pure prose. Build stays OS-agnostic — only the *agent's choice of script language* varies per host.
- **Not a new tier in the pipeline.** No `src/pipeline/native-script/` module. The tiering decision lives in the agent's reasoning layer (informed by SKILL.md), not in clawdcursor's code.
- **Not a registry of `(app, intent) → script` mappings.** Those rot every time an app ships a new release. Letting the LLM pick the right `osascript` / PowerShell / D-Bus snippet at call time scales much better than a hand-curated list.

## Test plan

- [x] `git diff` shows only `SKILL.md` modified (11 insertions, 6 deletions).
- [x] No code paths touched — no build / typecheck / test suite needed.
- [ ] Skim the rendered Markdown on GitHub to confirm the callout block and the "When NOT to use" section read cleanly.
- [ ] (Optional) Re-run any existing SKILL.md lint / link check the repo has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)