### PR TITLE
fix: invoke-element timeout + smart_click foreground OCR filter (#71)

### DIFF
--- a/scripts/invoke-element.ps1
+++ b/scripts/invoke-element.ps1
@@ -149,29 +149,59 @@ try {
     # Execute the requested action
     switch ($Action) {
         "click" {
-            # Try InvokePattern first, then fall back to SetFocus + boundary click info
-            try {
-                $pattern = $element.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)
-                $pattern.Invoke()
-                [Console]::Out.Write((@{ success = $true; action = "click"; method = "InvokePattern" } | ConvertTo-Json -Compress))
-            } catch {
-                # If InvokePattern not supported, try TogglePattern (for checkboxes)
+            # Some web/Electron buttons advertise InvokePattern but block on Invoke()
+            # without ever throwing — caller would hang indefinitely. Wrap the pattern
+            # call in a Task with a 2s timeout, then fall through to the bounds-fallback
+            # JSON the legacy catch path already produces. See issue #71.
+            $rect = $element.Current.BoundingRectangle
+            $clickX = [int]($rect.X + $rect.Width / 2)
+            $clickY = [int]($rect.Y + $rect.Height / 2)
+
+            # Result is mutated by the Task action via reference (PSCustomObject).
+            # Closure capture (.GetNewClosure()) keeps $element and $invokeResult
+            # references valid inside the Task delegate.
+            $invokeResult = [PSCustomObject]@{ Method = $null; Error = $null }
+            $localElement = $element
+            $invokeBlock = {
                 try {
-                    $togglePattern = $element.GetCurrentPattern([System.Windows.Automation.TogglePattern]::Pattern)
-                    $togglePattern.Toggle()
-                    [Console]::Out.Write((@{ success = $true; action = "click"; method = "TogglePattern" } | ConvertTo-Json -Compress))
+                    $p = $localElement.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)
+                    $p.Invoke()
+                    $invokeResult.Method = "InvokePattern"
                 } catch {
-                    # Last resort: report bounds so caller can click by coordinates
-                    $rect = $element.Current.BoundingRectangle
-                    $clickX = [int]($rect.X + $rect.Width / 2)
-                    $clickY = [int]($rect.Y + $rect.Height / 2)
-                    [Console]::Out.Write((@{
-                        success  = $false
-                        action   = "click"
-                        error    = "No InvokePattern or TogglePattern supported. Use coordinate click."
-                        clickPoint = @{ x = $clickX; y = $clickY }
-                    } | ConvertTo-Json -Depth 5 -Compress))
+                    try {
+                        $p = $localElement.GetCurrentPattern([System.Windows.Automation.TogglePattern]::Pattern)
+                        $p.Toggle()
+                        $invokeResult.Method = "TogglePattern"
+                    } catch {
+                        $invokeResult.Error = $_.Exception.Message
+                    }
                 }
+            }.GetNewClosure()
+
+            $task = [System.Threading.Tasks.Task]::Run([System.Action]$invokeBlock)
+            $completedInTime = $task.Wait(2000)
+
+            if ($completedInTime -and $invokeResult.Method) {
+                # Pattern call returned within timeout — success
+                [Console]::Out.Write((@{ success = $true; action = "click"; method = $invokeResult.Method } | ConvertTo-Json -Compress))
+            } elseif ($completedInTime) {
+                # Pattern call returned but threw on both Invoke and Toggle — bounds fallback (legacy behaviour)
+                [Console]::Out.Write((@{
+                    success    = $false
+                    action     = "click"
+                    error      = "No InvokePattern or TogglePattern supported. Use coordinate click."
+                    clickPoint = @{ x = $clickX; y = $clickY }
+                } | ConvertTo-Json -Depth 5 -Compress))
+            } else {
+                # Hung past 2s — element advertises a pattern but does not honour it (typical for
+                # React/Chromium buttons wired to onclick). The Task is left to finish on its own;
+                # the PowerShell process will exit shortly and clean it up.
+                [Console]::Out.Write((@{
+                    success    = $false
+                    action     = "click"
+                    error      = "InvokePattern timed out after 2s (element advertises pattern but blocks on Invoke). Use coordinate click."
+                    clickPoint = @{ x = $clickX; y = $clickY }
+                } | ConvertTo-Json -Depth 5 -Compress))
             }
         }
         "set-value" {

--- a/src/tools/smart.ts
+++ b/src/tools/smart.ts
@@ -216,35 +216,64 @@ export function getSmartTools(): ToolDefinition[] {
         // OCR finds text coordinates, a11y tries invoke — whoever succeeds first wins.
 
         // Start OCR scan
-        const ocrPromise = (async (): Promise<{ x: number; y: number; text: string } | null> => {
+        const ocrPromise = (async (): Promise<{ x: number; y: number; text: string; warning?: string } | null> => {
           try {
             const engine = getOcr();
             if (!engine.isAvailable()) return null;
             const result = await engine.recognizeScreen();
             const targetLower = target.toLowerCase();
 
-            let bestMatch: any = null;
-            let bestScore = 0;
-
-            for (const el of result.elements) {
-              const elText = el.text.toLowerCase();
-              if (elText === targetLower) {
-                bestMatch = el; bestScore = 1; break;
+            // Pick best OCR candidate from a (possibly filtered) subset.
+            // Returns null when no candidate clears the 0.3 score threshold.
+            const pickBest = (candidates: typeof result.elements) => {
+              let best: typeof candidates[number] | null = null;
+              let bestScore = 0;
+              for (const el of candidates) {
+                const elText = el.text.toLowerCase();
+                if (elText === targetLower) { best = el; bestScore = 1; break; }
+                if (elText.includes(targetLower) || targetLower.includes(elText)) {
+                  const score = Math.min(elText.length, targetLower.length) / Math.max(elText.length, targetLower.length);
+                  if (score > bestScore) { best = el; bestScore = score; }
+                }
               }
-              if (elText.includes(targetLower) || targetLower.includes(elText)) {
-                const score = Math.min(elText.length, targetLower.length) / Math.max(elText.length, targetLower.length);
-                if (score > bestScore) { bestMatch = el; bestScore = score; }
+              return best && bestScore > 0.3 ? { match: best, score: bestScore } : null;
+            };
+
+            // Prefer matches inside the focused window's bounds — full-screen OCR can
+            // see text in background windows (e.g. Outlook visible behind a "Pick an
+            // account" dialog showing the same email). Only widen to the full screen
+            // when the foreground window has no match. See issue #71.
+            const winBounds = activeWin?.bounds;
+            let pick: { match: typeof result.elements[number]; score: number } | null = null;
+            let warning: string | undefined;
+
+            if (winBounds && winBounds.width > 0 && winBounds.height > 0) {
+              const inWindow = result.elements.filter(el => {
+                const cx = el.x + el.width / 2;
+                const cy = el.y + el.height / 2;
+                return cx >= winBounds.x && cx < winBounds.x + winBounds.width &&
+                       cy >= winBounds.y && cy < winBounds.y + winBounds.height;
+              });
+              pick = pickBest(inWindow);
+            }
+
+            // Fall through to full-screen only if foreground produced nothing.
+            // Annotate the response so the caller has a signal that the click may
+            // have landed in a background window.
+            if (!pick) {
+              pick = pickBest(result.elements);
+              if (pick && winBounds && winBounds.width > 0) {
+                warning = 'matched outside focused window';
               }
             }
 
-            if (bestMatch && bestScore > 0.3) {
-              return {
-                x: bestMatch.x + Math.round(bestMatch.width / 2),
-                y: bestMatch.y + Math.round(bestMatch.height / 2),
-                text: bestMatch.text,
-              };
-            }
-            return null;
+            if (!pick) return null;
+            return {
+              x: pick.match.x + Math.round(pick.match.width / 2),
+              y: pick.match.y + Math.round(pick.match.height / 2),
+              text: pick.match.text,
+              warning,
+            };
           } catch { return null; }
         })();
 
@@ -292,7 +321,8 @@ export function getSmartTools(): ToolDefinition[] {
         if (ocrMatch) {
           await ctx.desktop.mouseClick(ocrMatch.x, ocrMatch.y);
           ctx.a11y.invalidateCache();
-          return { text: `Clicked "${target}" via OCR (matched "${ocrMatch.text}" at ${ocrMatch.x},${ocrMatch.y})` };
+          const warningSuffix = ocrMatch.warning ? `  [WARNING: ${ocrMatch.warning} — verify with read_screen]` : '';
+          return { text: `Clicked "${target}" via OCR (matched "${ocrMatch.text}" at ${ocrMatch.x},${ocrMatch.y})${warningSuffix}` };
         }
 
         // a11y had bounds but couldn't invoke — coordinate fallback


### PR DESCRIPTION
## Summary

Two narrow reliability fixes for [issue #71](https://github.com/AmrDab/clawdcursor/issues/71). Both patches activate only on the documented failure modes — every existing happy path is untouched.

### 1. `scripts/invoke-element.ps1` — 2s timeout on pattern Invoke

**Bug:** React/Electron buttons sometimes advertise `InvokePattern` via UIA but block on `Invoke()` without ever throwing. The legacy try/catch fallback chain (`Invoke` → `Toggle` → bounds JSON) only kicks in when a pattern *throws*, so a silent hang consumes the script.

**Fix:** Wrap the pattern call in a `System.Threading.Tasks.Task` with a 2s `Wait(timeout)`. On timeout, emit the same bounds-fallback JSON the legacy catch already produces (plus a clearer error message). The Task is left to finish in the background — the PowerShell process exits shortly and cleans it up.

**Compatibility:** Happy-path output is byte-identical. New code path activates only when `Invoke()` blocks past 2s.

### 2. `src/tools/smart.ts` — prefer OCR matches inside the focused window

**Bug:** Full-screen OCR could match text in background windows (Outlook visible behind a "Pick an account" dialog showing the same email address). The existing scoring loop took the first exact match anywhere on screen and reported `success: true` — a silent false positive.

**Fix:** Refactor candidate ranking into a `pickBest()` helper, then run two passes:
1. First pass: only OCR elements whose centroid is inside `activeWin.bounds`
2. Fall through to full-screen *only* when the foreground produced no match, and annotate the response with `warning: 'matched outside focused window'`

The warning is surfaced into the `smart_click` success message so the agent has a signal to verify with `read_screen`.

**Compatibility:** Behaviour is identical to before when the foreground window contains the target. The fall-through path is a strict superset of the old behaviour (same match, plus a warning).

### Issue #71 status

| Issue | This PR |
|---|---|
| 1. `invoke-element.ps1` hang | ✅ fixed |
| 2. `smart_click` cross-window OCR | ✅ fixed |
| 3. PowerShell `-File` arg quoting | not addressed — `com-excel-write.ps1` doesn't exist in this repo and no current script takes inline JSON params; sound advice for future scripts but no actual breakage to fix today |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (74 pre-existing warnings, unchanged)
- [x] `npm run test:ci` — 30 files, 434 passing, 1 skipped
- [x] PowerShell parser sanity-check on `invoke-element.ps1`
- [x] Smoke test: `invoke-element.ps1` against an invalid PID still emits `{"error":"No window found...","success":false}`
- [ ] Manual repro on a real React button (Azure Portal "New identity" or similar) to confirm the timeout path emits the bounds JSON in ≤2.5s
- [ ] Manual repro of the Outlook-behind-dialog scenario to confirm `smart_click` no longer matches the background window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
