### PR TITLE
fix: three real bugs from the v0.8.5-branch ultrareview

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,10 @@ metadata:
   openclaw:
     requires: {}
     install:
-      - npm install -g clawdcursor
+      # clawdcursor isn't published to the npm registry — `npm install -g clawdcursor`
+      # would 404. The documented installer clones the repo into ~/clawdcursor,
+      # runs npm install + build, and `npm link`s the global shim.
+      - curl -fsSL https://clawdcursor.com/install.sh | bash
       - clawdcursor consent --accept
     skill_dir: ~/.openclaw/workspace/skills/clawdcursor
 ---

--- a/schema.snapshot.json
+++ b/schema.snapshot.json
@@ -1287,6 +1287,36 @@
       }
     },
     {
+      "name": "set_field_value",
+      "description": "Set the value of a named text field directly via accessibility — more reliable than focus+type for forms (no IME issues, no autocomplete races). Uses UIA ValuePattern on Windows and AXValue on macOS. Referenced as the delegate for the compact `accessibility({\"action\":\"set_value\", ...})` route.",
+      "category": "perception",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Accessibility name of the field"
+          },
+          "value": {
+            "type": "string",
+            "description": "Value to write"
+          },
+          "controlType": {
+            "type": "string",
+            "description": "Optional role filter (e.g. \"Edit\")"
+          },
+          "processId": {
+            "type": "number",
+            "description": "Scope to a process"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      }
+    },
+    {
       "name": "shortcuts_execute",
       "description": "Execute a keyboard shortcut by describing what you want to do (e.g. \"scroll down\", \"close tab\", \"upvote\"). Uses fuzzy matching against the shortcuts database. Provide context (active app name) for app-specific shortcuts like Reddit or Outlook.",
       "category": "keyboard",

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -5,6 +5,15 @@
  * to internal key identifiers used across the codebase.
  */
 
+/**
+ * Platform-aware "primary modifier" — `mod` resolves to Cmd on macOS and
+ * Ctrl on Windows/Linux. This matches the convention used by editor
+ * frameworks (CodeMirror, ProseMirror, Tiptap) and the v2 PlatformAdapter.
+ * Without this alias the legacy `NativeDesktop.keyPress` would either throw
+ * `Unknown key: "mod"` (Win/Linux) or silently drop the modifier on macOS.
+ */
+const PLATFORM_PRIMARY_MOD = process.platform === 'darwin' ? 'Super' : 'Control';
+
 /** Canonical key name map — input (case-insensitive) → normalized name */
 const KEY_ALIASES: Record<string, string> = {
   // Enter / Return
@@ -49,6 +58,10 @@ const KEY_ALIASES: Record<string, string> = {
   'cmd': 'Super',
   'command': 'Super',
   'command_l': 'Super',
+
+  // Platform-aware "primary" modifier — Cmd on macOS, Ctrl on Win/Linux.
+  // Resolved at module load via PLATFORM_PRIMARY_MOD above.
+  'mod': PLATFORM_PRIMARY_MOD,
 
   // Function keys
   'f1': 'F1', 'f2': 'F2', 'f3': 'F3', 'f4': 'F4',

--- a/src/native-desktop.ts
+++ b/src/native-desktop.ts
@@ -702,10 +702,13 @@ export class NativeDesktop extends EventEmitter {
     const key = parts[parts.length - 1] || keyCombo;
     const mods = parts.slice(0, -1).map(k => k.toLowerCase());
 
-    // Map modifier names to System Events syntax
+    // Map modifier names to System Events syntax.
+    // `mod` is the platform-aware "primary" modifier that resolves to Cmd
+    // on macOS — without this branch macKeyPress would silently type the
+    // bare letter (e.g. `mod+s` becomes a literal `s` keystroke).
     const modUsing: string[] = [];
     for (const m of mods) {
-      if (m === 'cmd' || m === 'command' || m === 'super') modUsing.push('command down');
+      if (m === 'cmd' || m === 'command' || m === 'super' || m === 'mod') modUsing.push('command down');
       else if (m === 'shift') modUsing.push('shift down');
       else if (m === 'alt' || m === 'option') modUsing.push('option down');
       else if (m === 'ctrl' || m === 'control') modUsing.push('control down');

--- a/src/pipeline/playbooks/keys-blocklist.ts
+++ b/src/pipeline/playbooks/keys-blocklist.ts
@@ -10,9 +10,20 @@
  * path (text-agent, vision-agent, MCP direct, REST /action, playbooks).
  */
 
-/** Normalize a user-supplied combo for comparison — lowercase, trim, collapse whitespace. */
+/**
+ * Platform-aware substitution for the `mod` modifier — resolves to `cmd` on
+ * macOS and `ctrl` on Windows/Linux. Mirrors the `mod` alias in `src/keys.ts`
+ * so `mod+q` on macOS is treated the same as `cmd+q` for blocklist matching.
+ */
+const PLATFORM_MOD_LOWER = process.platform === 'darwin' ? 'cmd' : 'ctrl';
+
+/** Normalize a user-supplied combo for comparison — lowercase, trim, collapse whitespace, resolve `mod`. */
 export function normalizeCombo(combo: string): string {
-  return combo.toLowerCase().replace(/\s+/g, '').replace(/[+_-]+/g, '+');
+  const flat = combo.toLowerCase().replace(/\s+/g, '').replace(/[+_-]+/g, '+');
+  // Resolve the platform-aware `mod` token in any position so `mod+q` matches
+  // `cmd+q` on macOS and `ctrl+q` (etc.) on Win/Linux.
+  if (!flat.includes('mod')) return flat;
+  return flat.split('+').map(p => p === 'mod' ? PLATFORM_MOD_LOWER : p).join('+');
 }
 
 /** Base set stored in normalized form. */

--- a/src/tools/a11y_depth.ts
+++ b/src/tools/a11y_depth.ts
@@ -109,6 +109,42 @@ export function getA11yDepthTools(): ToolDefinition[] {
       },
     },
 
+    // ── ValuePattern (text fields, combos, set value directly) ──
+
+    {
+      name: 'set_field_value',
+      description:
+        'Set the value of a named text field directly via accessibility — more ' +
+        'reliable than focus+type for forms (no IME issues, no autocomplete races). ' +
+        'Uses UIA ValuePattern on Windows and AXValue on macOS. Referenced as the ' +
+        'delegate for the compact `accessibility({"action":"set_value", ...})` route.',
+      parameters: {
+        name:        { type: 'string', description: 'Accessibility name of the field', required: true },
+        value:       { type: 'string', description: 'Value to write', required: true },
+        controlType: { type: 'string', description: 'Optional role filter (e.g. "Edit")', required: false },
+        processId:   { type: 'number', description: 'Scope to a process', required: false },
+      },
+      category: 'perception',
+      handler: async ({ name, value, controlType, processId }, ctx) => {
+        await ctx.ensureInitialized();
+        if (!ctx.platform) return needPlatform('set_field_value');
+        if (ctx.platform.platform === 'linux') return notSupportedOnLinux('set_field_value');
+        const pid = await resolveProcessId(ctx, processId);
+        const res = await ctx.platform.invokeElement({
+          name: String(name),
+          controlType,
+          processId: pid,
+          action: 'set-value',
+          value: String(value),
+        });
+        if (!res.success) {
+          return { text: `set_field_value failed for "${name}".`, isError: true };
+        }
+        const preview = String(value).length > 40 ? String(value).slice(0, 40) + '…' : String(value);
+        return { text: `Set "${name}" = "${preview}".` };
+      },
+    },
+
     // ── Toggle pattern (checkboxes, switches, toggle buttons) ──
 
     {


### PR DESCRIPTION
## Summary

Audited all 7 findings from the ultrareview run on `claude/sleepy-kowalevski-a1181c` (the v0.8.5 branch) against **current main** (v0.8.7 + recent dep bumps). The branch has had two follow-up releases on top, so several findings were already addressed.

### Verdict per finding

| # | Severity | Status |
|---|---|---|
| bug_002 README "What's New" stale | nit | ✅ already fixed in v0.8.7 |
| bug_003 MCP server hardcoded `0.7.2` | pre-existing | ✅ already fixed in v0.8.6 + PR #67 (single-source `VERSION`) |
| bug_007 docs `# wire into your agent (MCP)` | nit | ✅ already fixed in v0.8.6 |
| bug_004 cmd+q not blocked on MCP/REST | normal | ✅ already fixed in PR #69 — `evaluateToolCall` runs `evaluate()` against the full 16-entry blocklist at every direct-tool entry point |
| **bug_001** `mod+...` crashes / silently drops | normal | **fixed here** |
| **bug_005** compact `set_value` delegates to unregistered tool | pre-existing | **fixed here** |
| **bug_008** OpenClaw install uses `npm install -g` (404) | pre-existing | **fixed here** |

### Fixes in this PR

#### 1. `mod` modifier handling (bug_001)

The legacy `NativeDesktop` (which `ctx.desktop` binds to) had no `mod` translation — only the v2 `PlatformAdapter` did. Three coordinated changes:

- **`src/keys.ts`**: add `mod` to `KEY_ALIASES`, resolved at module load to `Super` on darwin and `Control` elsewhere. Mirrors the v2 adapter convention.
- **`src/native-desktop.ts`**: extend the `macKeyPress` modifier loop to treat `mod` as `command down`. The loop does direct string comparison, not normalisation, so the alias alone wasn't enough.
- **`src/pipeline/playbooks/keys-blocklist.ts`**: extend `normalizeCombo` so `mod+q` matches `cmd+q` on darwin and `ctrl+q` on Win/Linux — otherwise the safety gate would let `mod+q` through.

Closes the gap where `computer({"action":"key","combo":"mod+s"})` (the canonical example all over SKILL.md) would either throw `Unknown key: "mod"` (Win/Linux) or silently type a literal `s` (macOS, no Cmd modifier).

#### 2. Compact `accessibility({"action":"set_value"})` (bug_005)

`compact.ts:93` delegates to `set_field_value`, but no granular tool by that name was registered (only the agent-internal palettes at `src/v2/agent/tools.ts:224` and `src/pipeline/agent/tools.ts:124` had it). Calls returned `{isError: true, text: "delegate not registered"}`.

Registered `set_field_value` in `getA11yDepthTools()` mirroring the existing `a11y_expand` / `a11y_toggle` pattern: `ctx.platform.invokeElement` with `action: 'set-value'`. Schema snapshot regenerated (74 → 75 tools).

#### 3. SKILL.md OpenClaw install metadata (bug_008)

`metadata.openclaw.install` step 1 was `npm install -g clawdcursor`, but the package isn't published to npm (404). OpenClaw following the YAML verbatim would abort step 1 before reaching `clawdcursor consent --accept`.

Replaced with the documented `curl -fsSL https://clawdcursor.com/install.sh | bash` path, matching every other doc surface (README, install.sh, install.ps1).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (74 pre-existing warnings, unchanged)
- [x] `npm run test:ci` — 30 files, 434 passing, 1 skipped
- [x] `npm run test:mcp-schema-snapshot:update` — schema regenerated, 75 tools (was 74; +1 for `set_field_value`)
- [x] Verified diff: schema only adds `set_field_value`, no other tool changed
- [ ] Manual repro on macOS: `computer({"action":"key","combo":"mod+s"})` should now invoke Cmd+S (was: typing literal `s`)
- [ ] Manual repro on Windows: `computer({"action":"key","combo":"mod+s"})` should now invoke Ctrl+S (was: throwing `Unknown key: "mod"`)
- [ ] Manual repro: `accessibility({"action":"set_value","name":"Email","value":"x@y.com"})` should set the value (was: `delegate not registered` error)

## Compatibility

- **No breaking changes.** All three fixes activate previously-broken paths without altering any working path.
- The granular `key_press` handler still rejects the same 3 entries it always did at `src/tools/desktop.ts:13` (defense-in-depth alongside the upstream safety gate).
- The granular `set_field_value` tool is additive — existing tools and their schemas are unchanged.
- The `mod` alias resolution is platform-deterministic at module load — no runtime branch on platform inside hot paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
