### PR TITLE
chore(lint): clear all 10 unused-vars warnings surfaced as CI annotations

### DIFF
--- a/src/__tests__/mcp-schema-snapshot.test.ts
+++ b/src/__tests__/mcp-schema-snapshot.test.ts
@@ -11,7 +11,6 @@
 
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
-import * as path from 'path';
 import { currentSnapshot, readStoredSnapshot, snapshotPath } from '../schema/snapshot';
 
 describe('MCP schema snapshot', () => {

--- a/src/__tests__/observability.test.ts
+++ b/src/__tests__/observability.test.ts
@@ -6,7 +6,7 @@
  * correct from day one.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { CostMeter, priceFor } from '../pipeline/observability/cost-meter';
 import {
   newCorrelationId,

--- a/src/__tests__/smart-tools.test.ts
+++ b/src/__tests__/smart-tools.test.ts
@@ -278,7 +278,7 @@ describe('Smart Tools', () => {
     it('clicks to focus when UIA focus fails but bounds available', async () => {
       mockInvokeElement.mockResolvedValue({ success: false, clickPoint: { x: 400, y: 250 } });
       const ctx = createCtx();
-      const result = await smartType.handler({ text: 'test', target: 'Input field' }, ctx);
+      await smartType.handler({ text: 'test', target: 'Input field' }, ctx);
       // Should click at coordinates directly (no a11yToMouse conversion)
       expect(mockMouseClick).toHaveBeenCalledWith(400, 250);
       expect(mockWriteClipboard).toHaveBeenCalledWith('test');

--- a/src/__tests__/verifiers.test.ts
+++ b/src/__tests__/verifiers.test.ts
@@ -3,7 +3,7 @@
  * All a11y and LLM calls are mocked — no native desktop access.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 // ── Mock native deps ──────────────────────────────────────────────────────────
 vi.mock('@nut-tree-fork/nut-js', () => ({
@@ -18,9 +18,8 @@ vi.mock('sharp', () => ({
   default: vi.fn(() => ({ resize: vi.fn().mockReturnThis(), png: vi.fn().mockReturnThis(), toBuffer: vi.fn().mockResolvedValue(Buffer.from('')) })),
 }));
 
-import { TaskVerifier, type VerifyResult } from '../verifiers';
+import { TaskVerifier } from '../verifiers';
 import type { AccessibilityBridge } from '../accessibility';
-import type { PipelineConfig } from '../providers';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function makeA11y(overrides?: Partial<any>): AccessibilityBridge {
@@ -33,18 +32,6 @@ function makeA11y(overrides?: Partial<any>): AccessibilityBridge {
     isShellAvailable: vi.fn().mockResolvedValue(true),
     warmup: vi.fn().mockResolvedValue(undefined),
     ...overrides,
-  } as any;
-}
-
-function makePipelineConfig(textModelOverride?: any): PipelineConfig {
-  return {
-    provider: 'openai',
-    providerKey: 'sk-test',
-    apiKey: 'sk-test',
-    layer1: { enabled: true },
-    layer2: { enabled: true, model: 'gpt-4o-mini', baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-test', provider: 'openai' },
-    layer3: { enabled: false, model: 'gpt-4o', baseUrl: '', apiKey: '', provider: 'openai' },
-    ...(textModelOverride ?? {}),
   } as any;
 }
 

--- a/src/a11y-reasoner.ts
+++ b/src/a11y-reasoner.ts
@@ -1076,7 +1076,7 @@ export class A11yReasoner {
     };
   }
 
-  private parseResponse(response: string, step?: number): any {
+  private parseResponse(response: string, _step?: number): any {
     // Strip markdown code fences (haiku often wraps in ```json ... ```)
     const stripped = response.replace(/```(?:json)?\s*/g, '').replace(/```\s*/g, '').trim();
 
@@ -1101,7 +1101,7 @@ export class A11yReasoner {
         if (depth === 0) {
           try {
             return JSON.parse(stripped.slice(start, i + 1));
-          } catch (e) {
+          } catch {
             return { action: 'unsure', description: 'Failed to parse LLM JSON' };
           }
         }
@@ -1256,7 +1256,7 @@ export class A11yReasoner {
       this.cdpAvailable = true;
       const ctx = await this.cdpDriver.getPageContext();
       return '\n\n⚠️ CDP PAGE CONTEXT — you MUST use cdp_click/cdp_type/cdp_read_text actions (NOT key_press) to interact with this page:\n' + ctx;
-    } catch (err) {
+    } catch {
       this.cdpAvailable = false;
       this.cdpDriver = null;
       return null;


### PR DESCRIPTION
## Summary

The CI annotation cap was surfacing 60 line items (10 unique warnings × 6 OS/Node matrix combos). All were `@typescript-eslint/no-unused-vars` warnings — pre-existing on main, no functional impact, but noisy. Cleared every one of them with the smallest patches possible.

## Counters

- **Before:** 74 lint warnings (0 errors)
- **After:** 64 lint warnings (0 errors)
- **Tests:** 30 files, 434 passing, 1 skipped — unchanged

## What changed

**Tests** — drop unused imports / dead helpers:
- `mcp-schema-snapshot.test.ts`: drop `path` import
- `observability.test.ts`: drop `afterEach`, `vi` from import
- `smart-tools.test.ts`: drop `result` assignment (test only asserts on the mocks)
- `verifiers.test.ts`: drop `beforeEach`, `VerifyResult`, `PipelineConfig`, and the 12-line dead `makePipelineConfig` helper

**Source** — `src/a11y-reasoner.ts`:
- L1079: rename `step` arg to `_step` (eslint config already allows `^_/u` prefix for unused args)
- L1104: drop the binding on `catch (e)` (the error wasn't used)
- L1259: drop the binding on `catch (err)` (same)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:tests` — clean
- [x] `npm run lint` — 0 errors, 64 warnings (was 74)
- [x] `npm run test:ci` — 434 passing, 1 skipped

## Compatibility

Pure cleanup. No runtime change, no schema change, no API change. All removed identifiers were already unused — TypeScript and ESLint both confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
