### PR TITLE
fix(mcp): exit on stdin close so server doesn't outlive its host

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1011,6 +1011,11 @@ program
     const releaseMcp = () => { releasePidFile('mcp'); process.exit(0); };
     process.on('SIGINT', releaseMcp);
     process.on('SIGTERM', releaseMcp);
+    // Exit when our stdio parent dies (host crash, terminal close on Windows, etc.).
+    // Abrupt parent termination doesn't deliver SIGTERM on Windows, but the stdin
+    // pipe still closes — without this the MCP server lingers as a zombie.
+    process.stdin.on('end', releaseMcp);
+    process.stdin.on('close', releaseMcp);
   });
 
 // ── Tool Server (model-agnostic, no LLM needed) ──


### PR DESCRIPTION
## Summary
The `mcp` command only listens for SIGINT/SIGTERM. On Windows, abrupt host termination (Claude Code crash, terminal closed, parent process killed) doesn't deliver SIGTERM to node children, so the MCP server lingers as a zombie. One user accumulated 3 orphan `clawdcursor mcp` processes — oldest was 5 days alive — across host restarts.

Fix: also listen for stdin `'end'` and `'close'`, and shut down through the same release path. When the stdio parent dies, its end of the pipe closes; we detect that and exit cleanly. This is the standard MCP-stdio shutdown pattern.

Five-line change in `src/index.ts`, MCP mode only — `start`/`serve`/`stop` lifecycles untouched.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Spawn \`node dist/index.js mcp\` with stdin piped from a parent process; kill the parent abruptly (\`taskkill /F\` on Windows, \`kill -9\` on Linux). Without the fix the child survives; with the fix it exits within milliseconds.
- [ ] Terminal Ctrl+C still triggers SIGINT path (unchanged).
- [ ] Pidfile is released on stdin-close path (same \`releaseMcp\` callback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)