### PR TITLE
feat(providers): default DeepSeek to V4-Pro (1M context, Opus-tier coding)

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -122,9 +122,22 @@ export const PROVIDERS: Record<string, ProviderProfile> = {
     name: 'DeepSeek',
     baseUrl: 'https://api.deepseek.com/v1',
     authHeader: (key) => ({ 'Authorization': `Bearer ${key}` }),
-    textModel: 'deepseek-chat',
-    visionModel: 'deepseek-chat',
-    textContextWindow: 64000,
+    // DeepSeek V4 (April 2026) — flagship `deepseek-v4-pro` (1.6T MoE,
+    // ~Claude-Opus-tier on coding, 1M context, ~7× cheaper than Opus).
+    // `deepseek-v4-flash` is the budget alternative (284B MoE).
+    // Legacy `deepseek-chat` and `deepseek-reasoner` deprecate 2026-07-24
+    // and map to V4-Flash non-thinking / thinking respectively. clawdcursor
+    // defaults to Pro for better tool-use reliability — users can override
+    // via --text-model or .clawdcursor-config.json.
+    textModel: 'deepseek-v4-pro',
+    // DeepSeek has no native vision model. The visionModel field is a
+    // placeholder so the provider profile stays uniform; for vision
+    // workflows pair with Anthropic / GPT-4o / Gemini Flash via a mixed
+    // pipeline (text=DeepSeek, vision=other).
+    visionModel: 'deepseek-v4-pro',
+    // V4 ships with a 1M-token context window. The 64k figure was the
+    // V3-era default.
+    textContextWindow: 1_000_000,
     openaiCompat: true,
     computerUse: false,
     supportsJsonMode: true,


### PR DESCRIPTION
## Summary

- Default DeepSeek text model bumped from `deepseek-chat` (V3-era, 64k ctx) → `deepseek-v4-pro` (1.6T MoE, 1M ctx, Claude-Opus-tier coding).
- Context window in the provider profile updated 64,000 → 1,000,000 to match V4's actual ceiling.
- Provider profile shape is unchanged: still OpenAI-compatible, same `baseUrl`, same auth header — no new code paths, no new env vars, no new dependencies.

## Why Pro by default

DeepSeek V4 launched 2026-04-24 with two MoE variants:

| | params (total / active) | context | mode |
|---|---|---|---|
| `deepseek-v4-pro` | 1.6T / 49B | 1M | thinking + non-thinking |
| `deepseek-v4-flash` | 284B / 13B | 1M | thinking + non-thinking |

Pro is roughly Claude-Opus-tier on coding benchmarks at ~7× lower price, and tool-use reliability matters more than per-token cost for an agent loop. Budget-conscious users can still flip to Flash via `--text-model deepseek-v4-flash` or `.clawdcursor-config.json`.

The legacy names `deepseek-chat` and `deepseek-reasoner` deprecate **2026-07-24** and currently route to V4-Flash anyway, so leaving the default at `deepseek-chat` would silently surprise users at the deprecation cliff.

## What this PR does NOT do

- **No new MODEL_QUIRKS entry.** V4 thinking mode silently ignores `temperature` rather than rejecting it (unlike legacy `deepseek-reasoner`, which 400s on `temperature ≠ 1`). The existing request flow works as-is for V4. A quirk for legacy `deepseek-reasoner` would be additive and is tracked as a follow-up once #82's `MODEL_QUIRKS` infra lands on main.
- **No native vision.** DeepSeek still ships text-only. `visionModel` keeps the text-model name as a placeholder so the provider profile shape stays uniform; real vision needs a mixed pipeline (text=DeepSeek, vision=Anthropic / GPT-4o / Gemini Flash).

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors (64 pre-existing warnings unchanged).
- [x] `npm test` — 434/435 passing (1 pre-existing skip), no diff in failure pattern.
- [ ] Manual smoke test against the live DeepSeek API once a user provides a `DEEPSEEK_API_KEY` (the provider plumbing is unchanged, so this is just verifying the new model name is accepted by the endpoint).

## Follow-ups

- Add `MODEL_QUIRKS` entry for `deepseek-reasoner` (legacy R1 rejects `temperature ≠ 1`) — depends on #82 merging first.
- Once a vision-capable DeepSeek lands, update the `visionModel` field and drop the placeholder comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
