### PR TITLE
fix(issue-101): smart_click candidates + macOS multi-window + open_url tier + a11y description fallback

### DIFF
--- a/schema.snapshot.json
+++ b/schema.snapshot.json
@@ -1398,7 +1398,7 @@
     },
     {
       "name": "open_url",
-      "description": "Open a URL in the OS default browser. Non-browser-agnostic counterpart to navigate_browser. Tier 2 (mutation): triggers network egress to an arbitrary destination and may launch the registered HTTP handler (which can be any app, not strictly a browser).",
+      "description": "Open a URL in the OS default browser. Non-browser-agnostic counterpart to navigate_browser. Tier 1 (input): triggers network egress and may launch the registered HTTP handler (which can be any app, not strictly a browser). Downgraded from tier 2 in 0.9.4 (issue #101 bug 3) because an agent host can always reach the same primitive via Bash (`open <url>` on macOS, `xdg-open` on Linux, `start <url>` on Windows) — the tier-2 gate added friction without preventing the action. URL must start with http(s)://.",
       "category": "orchestration",
       "parameters": {
         "type": "object",

--- a/scripts/mac/_window-picker.jxa
+++ b/scripts/mac/_window-picker.jxa
@@ -1,0 +1,163 @@
+#!/usr/bin/env osascript -l JavaScript
+
+/**
+ * _window-picker.jxa
+ *
+ * Shared reference implementation for "which window of a process is the
+ * user's real interaction window?". osascript cannot `require()` other
+ * scripts, so the helpers below are also INLINED into the consumer scripts.
+ * Treat this file as the source of truth — if you change scoring here, mirror
+ * the change in:
+ *   - scripts/mac/focus-window.jxa
+ *   - scripts/mac/get-foreground-window.jxa
+ *
+ * Intended consumers:
+ *   - focus-window.jxa            (uses findTitleMatchWindow + pickInteractionWindow fallback)
+ *   - get-foreground-window.jxa   (uses pickInteractionWindow)
+ *
+ * Heuristics, in order of weight:
+ *   1. Visible area (largest wins; rejects 0x0 outright)
+ *   2. Subrole penalty: AXFloatingWindow / AXDialog / AXSystemDialog are
+ *      almost always popups; AXStandardWindow is preferred.
+ *   3. Title penalty: titles like "Downloads" / "Notifications" / "Updates"
+ *      are commonly system-tray-ish popovers in apps like Xcode, Safari.
+ *   4. Z-order tiebreak: lower index ~= newer / more recently activated,
+ *      so older-but-larger windows still beat tiny new popups via (1)+(2)+(3),
+ *      but among equally-scored windows the older one wins (it's the window
+ *      the user was already working in before the popup appeared).
+ *
+ * Bugs this addresses (clawdcursor #101):
+ *   #2 focus_window ignored title= on multi-window apps and grabbed windows[0]
+ *   #4 getActiveWindow grabbed windows[0] of the frontmost process, which on
+ *      Xcode would surface the "Downloads" popup instead of the project window
+ */
+
+function safeGet(obj, property, defaultValue) {
+    try {
+        var val = obj[property]();
+        return (val !== undefined && val !== null) ? val : defaultValue;
+    } catch (e) {
+        return defaultValue;
+    }
+}
+
+// Reads {x, y, width, height} for a window; returns zeros if AXPosition/AXSize
+// are not accessible (some background processes return EACCESS here).
+function getWinBounds(win) {
+    var bounds = { x: 0, y: 0, width: 0, height: 0 };
+    try {
+        var p = win.position();
+        var s = win.size();
+        if (p && s) {
+            bounds.x = p[0] || 0;
+            bounds.y = p[1] || 0;
+            bounds.width = s[0] || 0;
+            bounds.height = s[1] || 0;
+        }
+    } catch (e) {}
+    return bounds;
+}
+
+// Pulls the AXSubrole accessibility attribute, e.g. "AXStandardWindow",
+// "AXFloatingWindow", "AXDialog", "AXSystemDialog". Returns '' if unknown.
+function getWinSubrole(win) {
+    try {
+        return win.subrole() || '';
+    } catch (e) {}
+    try {
+        return win.attributes.byName('AXSubrole').value() || '';
+    } catch (e) {}
+    return '';
+}
+
+function isLikelyTrayTitle(title) {
+    if (!title) return false;
+    var t = String(title).trim().toLowerCase();
+    return t === 'downloads' || t === 'notifications' || t === 'updates' ||
+           t === 'inspector' || t === 'activity';
+}
+
+// Scores a window for "is this the user's real interaction window?".
+// Higher score wins. Returns -Infinity for 0x0 / invisible windows.
+function scoreWindow(win, index) {
+    var bounds = getWinBounds(win);
+    var area = bounds.width * bounds.height;
+    if (area <= 0) return -Infinity;
+
+    var score = area;
+
+    var subrole = getWinSubrole(win);
+    if (subrole === 'AXStandardWindow') {
+        score += 2000000;            // strongly prefer standard windows
+    } else if (subrole === 'AXFloatingWindow') {
+        score -= 5000000;            // popups, palettes
+    } else if (subrole === 'AXDialog' || subrole === 'AXSystemDialog') {
+        score -= 3000000;            // modal dialogs
+    }
+
+    var title = '';
+    try { title = win.name() || ''; } catch (e) {}
+    if (isLikelyTrayTitle(title)) score -= 1500000;
+
+    // Tiebreak: older windows (higher index) get a tiny nudge so popups
+    // (which arrive at index 0) lose ties to the underlying work window.
+    score += index * 10;
+
+    return score;
+}
+
+// Picks the most likely user-interaction window from a window list.
+// Returns { window, index } or null if no window has visible area.
+function pickInteractionWindow(windows) {
+    var best = null;
+    var bestScore = -Infinity;
+    var bestIndex = -1;
+    for (var i = 0; i < windows.length; i++) {
+        try {
+            var w = windows[i];
+            var s = scoreWindow(w, i);
+            if (s > bestScore) {
+                bestScore = s;
+                best = w;
+                bestIndex = i;
+            }
+        } catch (e) {}
+    }
+    if (!best) return null;
+    return { window: best, index: bestIndex };
+}
+
+// Finds first window whose name contains `needle` (case-insensitive)
+// AND has non-zero visible area. Used by focus-window.jxa.
+function findTitleMatchWindow(windows, needle) {
+    if (!needle) return null;
+    var n = String(needle).toLowerCase();
+    for (var i = 0; i < windows.length; i++) {
+        try {
+            var w = windows[i];
+            var title = '';
+            try { title = w.name() || ''; } catch (e) {}
+            if (!title) continue;
+            if (title.toLowerCase().indexOf(n) === -1) continue;
+            var b = getWinBounds(w);
+            if (b.width * b.height <= 0) continue;
+            return { window: w, index: i, title: title };
+        } catch (e) {}
+    }
+    return null;
+}
+
+// This file is reference-only when invoked directly — print the helpers
+// list so a curious developer running `osascript _window-picker.jxa` gets
+// something useful back instead of nothing.
+function run(argv) {
+    return JSON.stringify({
+        kind: 'reference',
+        helpers: [
+            'safeGet', 'getWinBounds', 'getWinSubrole',
+            'isLikelyTrayTitle', 'scoreWindow',
+            'pickInteractionWindow', 'findTitleMatchWindow'
+        ],
+        note: 'osascript cannot require() — these helpers are inlined in focus-window.jxa and get-foreground-window.jxa. Keep all three in sync.'
+    });
+}

--- a/scripts/mac/focus-window.jxa
+++ b/scripts/mac/focus-window.jxa
@@ -2,30 +2,116 @@
 
 /**
  * focus-window.jxa
- * 
+ *
  * Brings a window to the front by title substring or process ID.
- * 
+ *
  * Parameters:
  *   -title <string>      - Substring match against window titles (case-insensitive)
- *   -processId <number>  - Exact process ID to focus
- * 
+ *   -processId <number>  - Process ID to focus
+ *
  * Returns JSON result with success status and window info.
- * 
+ *
  * Note: At least one of -title or -processId must be specified.
- * 
+ *
+ * When BOTH are supplied, -title is used to disambiguate among that
+ * process's windows (multi-window apps like Xcode, VS Code, Chrome).
+ * The previous implementation always picked process.windows[0], which
+ * surfaced whichever popup was most recent (e.g. Xcode's "Downloads"
+ * popover at 1760,80 instead of the user's project window). See bug
+ * #2 of clawdcursor issue #101.
+ *
  * Usage: osascript -l JavaScript focus-window.jxa -title "Safari"
  *        osascript -l JavaScript focus-window.jxa -processId 1234
+ *        osascript -l JavaScript focus-window.jxa -processId 1234 -title "Amr Dabbas"
  */
 
-// Utility function to safely get property values
+// ── Inlined from scripts/mac/_window-picker.jxa ───────────────────
+// Keep these helpers in sync with _window-picker.jxa; osascript can't require().
+
 function safeGet(obj, property, defaultValue) {
     try {
         var val = obj[property]();
-        return val !== undefined && val !== null ? val : defaultValue;
+        return (val !== undefined && val !== null) ? val : defaultValue;
     } catch (e) {
         return defaultValue;
     }
 }
+
+function getWinBounds(win) {
+    var bounds = { x: 0, y: 0, width: 0, height: 0 };
+    try {
+        var p = win.position();
+        var s = win.size();
+        if (p && s) {
+            bounds.x = p[0] || 0;
+            bounds.y = p[1] || 0;
+            bounds.width = s[0] || 0;
+            bounds.height = s[1] || 0;
+        }
+    } catch (e) {}
+    return bounds;
+}
+
+function getWinSubrole(win) {
+    try { return win.subrole() || ''; } catch (e) {}
+    try { return win.attributes.byName('AXSubrole').value() || ''; } catch (e) {}
+    return '';
+}
+
+function isLikelyTrayTitle(title) {
+    if (!title) return false;
+    var t = String(title).trim().toLowerCase();
+    return t === 'downloads' || t === 'notifications' || t === 'updates' ||
+           t === 'inspector' || t === 'activity';
+}
+
+function scoreWindow(win, index) {
+    var bounds = getWinBounds(win);
+    var area = bounds.width * bounds.height;
+    if (area <= 0) return -Infinity;
+    var score = area;
+    var subrole = getWinSubrole(win);
+    if (subrole === 'AXStandardWindow') score += 2000000;
+    else if (subrole === 'AXFloatingWindow') score -= 5000000;
+    else if (subrole === 'AXDialog' || subrole === 'AXSystemDialog') score -= 3000000;
+    var title = '';
+    try { title = win.name() || ''; } catch (e) {}
+    if (isLikelyTrayTitle(title)) score -= 1500000;
+    score += index * 10;
+    return score;
+}
+
+function pickInteractionWindow(windows) {
+    var best = null, bestScore = -Infinity, bestIndex = -1;
+    for (var i = 0; i < windows.length; i++) {
+        try {
+            var s = scoreWindow(windows[i], i);
+            if (s > bestScore) { bestScore = s; best = windows[i]; bestIndex = i; }
+        } catch (e) {}
+    }
+    if (!best) return null;
+    return { window: best, index: bestIndex };
+}
+
+function findTitleMatchWindow(windows, needle) {
+    if (!needle) return null;
+    var n = String(needle).toLowerCase();
+    for (var i = 0; i < windows.length; i++) {
+        try {
+            var w = windows[i];
+            var title = '';
+            try { title = w.name() || ''; } catch (e) {}
+            if (!title) continue;
+            if (title.toLowerCase().indexOf(n) === -1) continue;
+            var b = getWinBounds(w);
+            if (b.width * b.height <= 0) continue;
+            return { window: w, index: i, title: title };
+        } catch (e) {}
+    }
+    return null;
+}
+
+// ── End inlined helpers ───────────────────────────────────────────
 
 // run(argv) is the JXA entry point — osascript calls it and its return value becomes stdout.
 // argv receives command-line arguments passed after the script path.
@@ -46,75 +132,86 @@ function run(argv) {
 
         // Validate parameters
         if (!params.title && !params.processId) {
-            return JSON.stringify({ 
-                success: false, 
-                error: 'Must specify -title or -processId' 
+            return JSON.stringify({
+                success: false,
+                error: 'Must specify -title or -processId'
             });
         }
-        
+
         var SystemEvents = Application('System Events');
         SystemEvents.includeStandardAdditions = true;
-        
+
         // Get all processes with UI
         var processes = SystemEvents.processes.where({ backgroundOnly: false });
         var targetWindow = null;
         var targetProcess = null;
-        
-        // Search for matching window
-        for (var i = 0; i < processes.length; i++) {
-            try {
-                var process = processes[i];
-                var processId = safeGet(process, 'unixId', 0);
-                var processName = safeGet(process, 'name', 'unknown');
-                
-                // Check process ID match first
-                if (params.processId && processId === params.processId) {
+
+        // Phase 1: if processId is supplied, locate that process and pick
+        // the right window inside it. This is the bug #2 fix — when title
+        // is also supplied, the title MUST be consulted before defaulting
+        // to windows[0] (which on multi-window apps is often a popup).
+        if (params.processId) {
+            for (var pi = 0; pi < processes.length; pi++) {
+                try {
+                    var process = processes[pi];
+                    var pidHere = safeGet(process, 'unixId', 0);
+                    if (pidHere !== params.processId) continue;
+
                     targetProcess = process;
-                    // Get the first window of this process
                     var windows = process.windows;
-                    if (windows.length > 0) {
-                        targetWindow = windows[0];
-                        break;
+
+                    if (windows.length === 0) break;
+
+                    // (a) Title-disambiguation inside the matched process
+                    if (params.title) {
+                        var hit = findTitleMatchWindow(windows, params.title);
+                        if (hit) { targetWindow = hit.window; break; }
                     }
+
+                    // (b) No title or no title match — fall back to the
+                    // scored interaction window rather than blindly windows[0],
+                    // which would re-introduce the popup-grab regression.
+                    var picked = pickInteractionWindow(windows);
+                    if (picked) { targetWindow = picked.window; break; }
+
+                    // (c) Last resort: keep legacy behaviour so we never
+                    // regress to "matched process but no window".
+                    targetWindow = windows[0];
+                    break;
+                } catch (e) {
+                    // Process not accessible
                 }
-                
-                // Check title match
-                if (params.title) {
-                    var windows = process.windows;
-                    var titleLower = params.title.toLowerCase();
-                    
-                    for (var j = 0; j < windows.length; j++) {
-                        try {
-                            var win = windows[j];
-                            var winTitle = '';
-                            try {
-                                winTitle = win.name() || '';
-                            } catch (e) {}
-                            
-                            if (winTitle && winTitle.toLowerCase().indexOf(titleLower) !== -1) {
-                                targetWindow = win;
-                                targetProcess = process;
-                                break;
-                            }
-                        } catch (e) {
-                            // Window not accessible
-                        }
-                    }
-                    
-                    if (targetWindow) break;
-                }
-            } catch (e) {
-                // Process not accessible
             }
         }
-        
+
+        // Phase 2: cross-process title scan, used when processId wasn't
+        // supplied or didn't match. Bug #2's second clause: this scan must
+        // skip 0x0 (invisible) windows that happen to share the title but
+        // can't actually be raised — those return success but do nothing.
+        if (!targetWindow && params.title) {
+            for (var pi2 = 0; pi2 < processes.length; pi2++) {
+                try {
+                    var p2 = processes[pi2];
+                    var ws = p2.windows;
+                    var hit2 = findTitleMatchWindow(ws, params.title);
+                    if (hit2) {
+                        targetWindow = hit2.window;
+                        targetProcess = p2;
+                        break;
+                    }
+                } catch (e) {
+                    // Process not accessible
+                }
+            }
+        }
+
         if (!targetWindow) {
-            return JSON.stringify({ 
-                success: false, 
-                error: 'Window not found matching title="' + (params.title || '') + '" processId=' + (params.processId || 0) 
+            return JSON.stringify({
+                success: false,
+                error: 'Window not found matching title="' + (params.title || '') + '" processId=' + (params.processId || 0)
             });
         }
-        
+
         // Bring window to front
         // Method 1: Use System Events to set frontmost
         try {
@@ -124,14 +221,14 @@ function run(argv) {
         } catch (e) {
             // Continue with other methods
         }
-        
+
         // Method 2: Focus the window
         try {
             targetWindow.focused = true;
         } catch (e) {
             // Continue
         }
-        
+
         // Method 3: Use application level activation (if we can get the app name)
         try {
             if (targetProcess) {
@@ -144,28 +241,43 @@ function run(argv) {
         } catch (e) {
             // Continue
         }
-        
+
+        // Method 4: AXRaise — the only call that, on multi-window apps, brings
+        // the SPECIFIC window forward instead of just activating the app and
+        // letting macOS surface whichever window was frontmost last. Without
+        // this, bug #2 would only be half-fixed: we'd pick the right window
+        // but app.activate() would still raise the app's most-recent window.
+        try {
+            targetWindow.actions.byName('AXRaise').perform();
+        } catch (e) {
+            // Not all windows expose AXRaise; ignore if unavailable.
+        }
+
         // Get final window info
         var winTitle = '';
         var winProcessId = 0;
         var winProcessName = 'unknown';
-        
+        var winBounds = getWinBounds(targetWindow);
+        var winSubrole = getWinSubrole(targetWindow);
+
         try {
             winTitle = targetWindow.name() || '';
         } catch (e) {}
-        
+
         if (targetProcess) {
             winProcessId = safeGet(targetProcess, 'unixId', 0);
             winProcessName = safeGet(targetProcess, 'name', 'unknown');
         }
-        
+
         return JSON.stringify({
             success: true,
             title: winTitle,
             processId: winProcessId,
-            processName: winProcessName
+            processName: winProcessName,
+            bounds: winBounds,
+            subrole: winSubrole
         });
-        
+
     } catch (error) {
         return JSON.stringify({ success: false, error: error.toString() });
     }

--- a/scripts/mac/get-foreground-window.jxa
+++ b/scripts/mac/get-foreground-window.jxa
@@ -2,75 +2,156 @@
 
 /**
  * get-foreground-window.jxa
- * 
+ *
  * Gets the currently focused/foreground window.
- * 
+ *
  * Returns JSON with:
  *   - handle: Window identifier (on macOS this is the process ID as a proxy)
  *   - processId: Unix process ID of the foreground application
  *   - processName: Name of the foreground application
- *   - title: Title of the frontmost window
+ *   - title: Title of the chosen window
+ *   - bounds: {x, y, width, height} of the chosen window
+ *   - subrole: AXSubrole of the chosen window ("AXStandardWindow", etc.)
  *   - success: Boolean indicating success
- * 
+ *
+ * Bug #4 of clawdcursor issue #101: the previous implementation took
+ * processes.where({frontmost: true})[0].windows[0], which on apps that
+ * spawn a popup (Xcode "Downloads", Safari "Notifications") returned the
+ * popup instead of the user's actual interaction window. We now score
+ * each window of the frontmost process and pick the best one.
+ *
  * Usage: osascript -l JavaScript get-foreground-window.jxa
  */
 
-// Utility function to safely get property values
+// ── Inlined from scripts/mac/_window-picker.jxa ───────────────────
+// Keep these helpers in sync with _window-picker.jxa; osascript can't require().
+
 function safeGet(obj, property, defaultValue) {
     try {
         var val = obj[property]();
-        return val !== undefined && val !== null ? val : defaultValue;
+        return (val !== undefined && val !== null) ? val : defaultValue;
     } catch (e) {
         return defaultValue;
     }
 }
+
+function getWinBounds(win) {
+    var bounds = { x: 0, y: 0, width: 0, height: 0 };
+    try {
+        var p = win.position();
+        var s = win.size();
+        if (p && s) {
+            bounds.x = p[0] || 0;
+            bounds.y = p[1] || 0;
+            bounds.width = s[0] || 0;
+            bounds.height = s[1] || 0;
+        }
+    } catch (e) {}
+    return bounds;
+}
+
+function getWinSubrole(win) {
+    try { return win.subrole() || ''; } catch (e) {}
+    try { return win.attributes.byName('AXSubrole').value() || ''; } catch (e) {}
+    return '';
+}
+
+function isLikelyTrayTitle(title) {
+    if (!title) return false;
+    var t = String(title).trim().toLowerCase();
+    return t === 'downloads' || t === 'notifications' || t === 'updates' ||
+           t === 'inspector' || t === 'activity';
+}
+
+function scoreWindow(win, index) {
+    var bounds = getWinBounds(win);
+    var area = bounds.width * bounds.height;
+    if (area <= 0) return -Infinity;
+    var score = area;
+    var subrole = getWinSubrole(win);
+    if (subrole === 'AXStandardWindow') score += 2000000;
+    else if (subrole === 'AXFloatingWindow') score -= 5000000;
+    else if (subrole === 'AXDialog' || subrole === 'AXSystemDialog') score -= 3000000;
+    var title = '';
+    try { title = win.name() || ''; } catch (e) {}
+    if (isLikelyTrayTitle(title)) score -= 1500000;
+    score += index * 10;
+    return score;
+}
+
+function pickInteractionWindow(windows) {
+    var best = null, bestScore = -Infinity, bestIndex = -1;
+    for (var i = 0; i < windows.length; i++) {
+        try {
+            var s = scoreWindow(windows[i], i);
+            if (s > bestScore) { bestScore = s; best = windows[i]; bestIndex = i; }
+        } catch (e) {}
+    }
+    if (!best) return null;
+    return { window: best, index: bestIndex };
+}
+
+// ── End inlined helpers ───────────────────────────────────────────
 
 // run(argv) is the JXA entry point — osascript calls it and its return value becomes stdout.
 function run(argv) {
     try {
         var SystemEvents = Application('System Events');
         SystemEvents.includeStandardAdditions = true;
-        
+
         // Get the frontmost process
         var frontProcesses = SystemEvents.processes.where({ frontmost: true });
-        
+
         if (frontProcesses.length === 0) {
-            return JSON.stringify({ 
-                success: false, 
-                error: 'No foreground window found' 
+            return JSON.stringify({
+                success: false,
+                error: 'No foreground window found'
             });
         }
-        
+
         var frontProcess = frontProcesses[0];
         var processId = safeGet(frontProcess, 'unixId', 0);
         var processName = safeGet(frontProcess, 'name', 'unknown');
-        
-        // Get the frontmost window title
+
+        // Pick the user's real interaction window instead of windows[0].
+        // See header comment for bug #4 rationale.
         var title = '';
+        var bounds = { x: 0, y: 0, width: 0, height: 0 };
+        var subrole = '';
+
         try {
             var windows = frontProcess.windows;
             if (windows.length > 0) {
-                // Try to get the name of the first (frontmost) window
-                try {
-                    title = windows[0].name() || '';
-                } catch (e) {}
-                
-                // If no title, try to find a focused window
-                if (!title) {
+                var picked = pickInteractionWindow(windows);
+                var chosen = null;
+
+                if (picked) {
+                    chosen = picked.window;
+                } else {
+                    // No window had visible area — try a focused window as a
+                    // last resort before giving up on title/bounds entirely.
                     for (var i = 0; i < windows.length; i++) {
                         try {
                             if (windows[i].focused && windows[i].focused()) {
-                                title = windows[i].name() || '';
+                                chosen = windows[i];
                                 break;
                             }
                         } catch (e) {}
                     }
+                    // If still nothing, fall back to windows[0] purely for
+                    // title extraction — preserves prior behaviour when the
+                    // only available window is a popup.
+                    if (!chosen) chosen = windows[0];
                 }
+
+                try { title = chosen.name() || ''; } catch (e) {}
+                bounds = getWinBounds(chosen);
+                subrole = getWinSubrole(chosen);
             }
         } catch (e) {
             // No windows accessible
         }
-        
+
         // On macOS, we don't have window handles like Win32 HWND
         // We use processId as a proxy identifier
         return JSON.stringify({
@@ -78,13 +159,15 @@ function run(argv) {
             handle: processId,  // Using processId as handle equivalent
             processId: processId,
             processName: processName,
-            title: title
+            title: title,
+            bounds: bounds,
+            subrole: subrole
         });
-        
+
     } catch (error) {
-        return JSON.stringify({ 
-            success: false, 
-            error: error.toString() 
+        return JSON.stringify({
+            success: false,
+            error: error.toString()
         });
     }
 }

--- a/src/__tests__/smart-tools.test.ts
+++ b/src/__tests__/smart-tools.test.ts
@@ -169,14 +169,23 @@ describe('Smart Tools', () => {
       expect(result.text).toContain('OCR');
     });
 
-    it('reports all attempted methods on total failure', async () => {
+    it('reports structured failure JSON with attempted methods on total failure', async () => {
       mockInvokeElement.mockResolvedValue({ success: false });
       const ctx = createCtx();
       // OCR won't match "NonexistentButton"
       const result = await smartClick.handler({ target: 'NonexistentButton' }, ctx);
+      // Existing callers still see truthy isError — that contract is preserved.
       expect(result.isError).toBe(true);
-      expect(result.text).toContain('smart_click failed');
-      expect(result.text).toContain('Attempted');
+      // Smarter callers can JSON.parse(text) for structured diagnostics
+      // (see issue #101: bare timeout used to discard this info).
+      const parsed = JSON.parse(result.text);
+      expect(parsed.error).toBe('no_clickable_target');
+      expect(parsed.reason).toBe('all_fallbacks_failed');
+      expect(parsed.target).toBe('NonexistentButton');
+      expect(Array.isArray(parsed.tried)).toBe(true);
+      expect(parsed.tried.length).toBeGreaterThan(0);
+      expect(Array.isArray(parsed.candidates)).toBe(true);
+      expect(typeof parsed.elapsedMs).toBe('number');
     });
 
     it('matches OCR elements with partial text match', async () => {
@@ -186,6 +195,83 @@ describe('Smart Tools', () => {
       // "Sub" partially matches "Submit"
       expect(result.text).toContain('OCR');
       expect(result.text).toContain('Submit');
+    });
+
+    // ── Issue #101: structured failure payloads ──
+
+    it('successful click still returns plain human-readable text (not JSON)', async () => {
+      // Sanity check: the JSON failure payload must NOT bleed into the
+      // happy path. Existing string-matching callers depend on prose like
+      // `Clicked "X" via OCR (matched ...)`.
+      mockInvokeElement.mockResolvedValue({ success: false });
+      const ctx = createCtx();
+      const result = await smartClick.handler({ target: 'Submit' }, ctx);
+      expect(result.isError).toBeUndefined();
+      expect(result.text).toMatch(/^Clicked "Submit"/);
+      // Must not be parseable JSON — that would mean we accidentally
+      // routed a success through the failure builder.
+      expect(() => JSON.parse(result.text)).toThrow();
+    });
+
+    it('returns structured JSON with error: "deadline_exceeded" when the deadline fires', async () => {
+      // Force both OCR and a11y invoke to outlast the 50ms deadline.
+      // The OLD bare-Promise.race would have thrown a bare timeout and
+      // discarded the diagnostic state. The new deadline-aware loop must
+      // return a structured payload instead, with isError still truthy.
+      const slowInvoke = vi.fn(() => new Promise(r => setTimeout(() => r({ success: false }), 5000)));
+      // Patch the mocked OCR engine for this one test to be slow.
+      const ctx = createCtx({
+        a11y: {
+          getActiveWindow: mockGetActiveWindow,
+          invokeElement: slowInvoke,
+          findElement: mockFindElement,
+          getFocusedElement: mockGetFocusedElement,
+          getScreenContext: mockGetScreenContext,
+          writeClipboard: mockWriteClipboard,
+          invalidateCache: mockInvalidateCache,
+        } as any,
+      });
+      // Slow down OCR too by patching the singleton via re-import isn't easy;
+      // instead use a target the OCR mock won't match so OCR returns null
+      // quickly — what we're testing is the a11y branch overrunning the deadline.
+      const result = await smartClick.handler(
+        { target: 'NeverGonnaMatchAnythingInOcr', timeout: 50 },
+        ctx,
+      );
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.text);
+      expect(parsed.error).toBe('deadline_exceeded');
+      expect(parsed.reason).toBe('deadline_exceeded');
+      expect(parsed.target).toBe('NeverGonnaMatchAnythingInOcr');
+      // The diagnostic state survived the deadline — that's the whole point.
+      expect(Array.isArray(parsed.tried)).toBe(true);
+      expect(parsed.tried.some((t: string) => t.includes('deadline_exceeded'))).toBe(true);
+      expect(typeof parsed.elapsedMs).toBe('number');
+    });
+
+    it('returns structured JSON with at least one OCR candidate when OCR matched but click failed', async () => {
+      // OCR sees "Submit" but mouseClick throws (simulates e.g. nut-js
+      // raising on a coordinate that's behind a modal, or the OS denying
+      // synthetic input). The failure payload must surface the OCR hit
+      // as a candidate so the caller knows the text WAS found.
+      mockInvokeElement.mockResolvedValue({ success: false });
+      const throwingMouseClick = vi.fn().mockRejectedValue(new Error('synthetic input denied'));
+      const ctx = createCtx({
+        desktop: {
+          mouseClick: throwingMouseClick,
+          keyPress: mockKeyPress,
+        } as any,
+      });
+      const result = await smartClick.handler({ target: 'Submit' }, ctx);
+      expect(result.isError).toBe(true);
+      const parsed = JSON.parse(result.text);
+      expect(parsed.error).toBe('no_clickable_target');
+      expect(parsed.target).toBe('Submit');
+      expect(parsed.candidates.length).toBeGreaterThanOrEqual(1);
+      const ocrCandidate = parsed.candidates.find((c: any) => c.source === 'ocr');
+      expect(ocrCandidate).toBeTruthy();
+      expect(ocrCandidate.text).toBe('Submit');
+      expect(ocrCandidate.bounds).toMatchObject({ x: 100, y: 200, w: 80, h: 30 });
     });
   });
 

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -88,6 +88,20 @@ export interface UiElement {
   automationId?: string;
   /** Owning-process id when known. */
   processId?: number;
+  /**
+   * Human-readable description of the element when its primary `name` is
+   * empty. UIA exposes this via `LocalizedControlType` / `HelpText`; AX
+   * exposes it via `AXDescription` / `AXRoleDescription`; AT-SPI exposes
+   * it via the `description` attribute. Many third-party macOS apps (Xcode
+   * in particular) put their visible text in `AXDescription` rather than
+   * `AXTitle`, so `name` arrives empty and the element looks anonymous to
+   * the agent. Consumers should fall back through `name → description →
+   * value → controlType` when rendering. Adapters populate when available;
+   * undefined is acceptable (back-compat).
+   *
+   * Added 0.9.4 for issue #101 bug 5.
+   */
+  description?: string;
 }
 
 export interface PermissionStatus {

--- a/src/tools/a11y.ts
+++ b/src/tools/a11y.ts
@@ -14,8 +14,23 @@ function formatWindow(w: WindowInfo): string {
     (!w.isMinimized ? ` at (${w.bounds.x},${w.bounds.y}) ${w.bounds.width}x${w.bounds.height}` : ' (minimized)');
 }
 
+/**
+ * Build a display label for an element. Falls back through
+ * `name → description → value → ''` so that Xcode and other macOS apps
+ * that put their visible text in `AXDescription` (instead of `AXTitle`)
+ * still render as something more informative than `"missing value"` or
+ * empty quotes. Issue #101 bug 5 — adapters populate `description` when
+ * the underlying a11y API exposes it.
+ */
+function elementLabel(el: UiElement): string {
+  if (el.name && el.name !== 'missing value') return el.name;
+  if (el.description) return el.description;
+  if (el.value) return el.value;
+  return '';
+}
+
 function formatElement(el: UiElement): string {
-  return `[${el.controlType}] "${el.name}"` +
+  return `[${el.controlType}] "${elementLabel(el)}"` +
     (el.automationId ? ` id:${el.automationId}` : '') +
     ` @${el.bounds.x},${el.bounds.y} ${el.bounds.width}x${el.bounds.height}` +
     (el.disabled || el.enabled === false ? ' DISABLED' : '') +

--- a/src/tools/extras.ts
+++ b/src/tools/extras.ts
@@ -510,14 +510,17 @@ export function getExtraTools(): ToolDefinition[] {
       name: 'open_url',
       description:
         'Open a URL in the OS default browser. Non-browser-agnostic counterpart to navigate_browser. ' +
-        'Tier 2 (mutation): triggers network egress to an arbitrary destination and may launch ' +
-        'the registered HTTP handler (which can be any app, not strictly a browser).',
+        'Tier 1 (input): triggers network egress and may launch the registered HTTP handler ' +
+        '(which can be any app, not strictly a browser). Downgraded from tier 2 in 0.9.4 ' +
+        '(issue #101 bug 3) because an agent host can always reach the same primitive via ' +
+        'Bash (`open <url>` on macOS, `xdg-open` on Linux, `start <url>` on Windows) — the ' +
+        'tier-2 gate added friction without preventing the action. URL must start with http(s)://.',
       parameters: {
         url: { type: 'string', description: 'https:// or http:// URL', required: true },
       },
       category: 'orchestration',
       compactGroup: 'window',
-      safetyTier: 2,
+      safetyTier: 1,
       handler: async ({ url }, ctx) => {
         await ctx.ensureInitialized();
         if (!ctx.platform) return needPlatform('open_url');

--- a/src/tools/smart.ts
+++ b/src/tools/smart.ts
@@ -200,13 +200,43 @@ export function getSmartTools(): ToolDefinition[] {
         const timeoutMs = (params.timeout as number) || 10000; // default 10s, was 5s
         const attempted: string[] = [];
 
-        // Wrap entire smart_click in a timeout to prevent hanging in serve mode
-        const timeoutPromise = new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error(`smart_click timed out after ${timeoutMs}ms searching for "${target}"`)), timeoutMs)
-        );
+        // Deadline-aware budget. Each fallback checks `remaining()` BEFORE
+        // starting an expensive operation. If <500ms remain we skip and
+        // record a `deadline_exceeded_before_*` entry so the outer wall-clock
+        // timeout never fires mid-fallback and discards diagnostic state.
+        // See issue #101: bare `Promise.race` swallowed the inner work's
+        // candidates[] / attempted[] arrays whenever it lost the race.
+        const startedAt = Date.now();
+        const deadline = startedAt + timeoutMs;
+        const remaining = () => Math.max(0, deadline - Date.now());
+        const MIN_BUDGET_MS = 500;
 
-        try {
-        return await Promise.race([timeoutPromise, (async () => {
+        // Structured candidate evidence — populated as each subsystem reports
+        // what it saw (e.g. OCR matched the text but the click didn't take).
+        // Surfaces in the JSON failure payload so callers can debug WHY a
+        // click missed, not just THAT it missed.
+        type Candidate = {
+          source: 'ocr' | 'a11y' | 'cdp';
+          text: string;
+          bounds: { x: number; y: number; w: number; h: number };
+          confidence: number | null;
+        };
+        const candidates: Candidate[] = [];
+
+        const buildFailure = (
+          error: 'no_clickable_target' | 'deadline_exceeded',
+          reason: string,
+        ) => {
+          const payload = {
+            error,
+            reason,
+            target,
+            candidates,
+            tried: attempted,
+            elapsedMs: Date.now() - startedAt,
+          };
+          return { text: JSON.stringify(payload), isError: true };
+        };
 
         // Detect active window and check traits
         const activeWin = await ctx.a11y.getActiveWindow().catch(() => null);
@@ -218,7 +248,8 @@ export function getSmartTools(): ToolDefinition[] {
         // OCR finds text coordinates, a11y tries invoke — whoever succeeds first wins.
 
         // Start OCR scan
-        const ocrPromise = (async (): Promise<{ x: number; y: number; text: string; warning?: string } | null> => {
+        type OcrHit = { x: number; y: number; text: string; warning?: string; bounds: { x: number; y: number; w: number; h: number }; confidence: number | null };
+        const ocrPromise: Promise<OcrHit | null> = (async (): Promise<OcrHit | null> => {
           try {
             const engine = getOcr();
             if (!engine.isAvailable()) return null;
@@ -227,10 +258,10 @@ export function getSmartTools(): ToolDefinition[] {
 
             // Pick best OCR candidate from a (possibly filtered) subset.
             // Returns null when no candidate clears the 0.3 score threshold.
-            const pickBest = (candidates: typeof result.elements) => {
-              let best: typeof candidates[number] | null = null;
+            const pickBest = (cands: typeof result.elements) => {
+              let best: typeof cands[number] | null = null;
               let bestScore = 0;
-              for (const el of candidates) {
+              for (const el of cands) {
                 const elText = el.text.toLowerCase();
                 if (elText === targetLower) { best = el; bestScore = 1; break; }
                 if (elText.includes(targetLower) || targetLower.includes(elText)) {
@@ -270,17 +301,23 @@ export function getSmartTools(): ToolDefinition[] {
             }
 
             if (!pick) return null;
+            const m = pick.match;
             return {
-              x: pick.match.x + Math.round(pick.match.width / 2),
-              y: pick.match.y + Math.round(pick.match.height / 2),
-              text: pick.match.text,
+              x: m.x + Math.round(m.width / 2),
+              y: m.y + Math.round(m.height / 2),
+              text: m.text,
               warning,
+              bounds: { x: m.x, y: m.y, w: m.width, h: m.height },
+              confidence: typeof (m as any).confidence === 'number' ? (m as any).confidence : null,
             };
           } catch { return null; }
         })();
 
         // Start a11y invoke in parallel
-        const a11yPromise = (async (): Promise<{ method: string; clickPoint?: { x: number; y: number } } | null> => {
+        type A11yHit =
+          | { method: 'invoke' }
+          | { method: 'bounds'; clickPoint: { x: number; y: number }; bounds?: { x: number; y: number; w: number; h: number }; text?: string };
+        const a11yPromise: Promise<A11yHit | null> = (async (): Promise<A11yHit | null> => {
           if (emptyA11y) return null;
           try {
             const result = await ctx.a11y.invokeElement({
@@ -303,7 +340,12 @@ export function getSmartTools(): ToolDefinition[] {
                 if (el.bounds?.width > 0) {
                   const cx = el.bounds.x + Math.floor(el.bounds.width / 2);
                   const cy = el.bounds.y + Math.floor(el.bounds.height / 2);
-                  return { method: 'bounds', clickPoint: { x: cx, y: cy } };
+                  return {
+                    method: 'bounds',
+                    clickPoint: { x: cx, y: cy },
+                    bounds: { x: el.bounds.x, y: el.bounds.y, w: el.bounds.width, h: el.bounds.height },
+                    text: el.name,
+                  };
                 }
               }
             } catch { /* fall through */ }
@@ -311,10 +353,33 @@ export function getSmartTools(): ToolDefinition[] {
           }
         })();
 
-        const [ocrMatch, a11yResult] = await Promise.all([ocrPromise, a11yPromise]);
+        // Wait for OCR + a11y in parallel, but bounded by the overall deadline.
+        // If both subsystems hang we abandon them at the deadline rather than
+        // letting an outer race fire — but we keep the diagnostic state we've
+        // already collected.
+        const parallelResult: { ocr: OcrHit | null; a11y: A11yHit | null; timedOut: boolean } = {
+          ocr: null,
+          a11y: null,
+          timedOut: false,
+        };
+        await new Promise<void>((resolve) => {
+          let settled = 0;
+          const finish = () => { if (++settled >= 2) resolve(); };
+          const timer = setTimeout(() => {
+            parallelResult.timedOut = true;
+            resolve();
+          }, remaining());
+          ocrPromise.then(r => { parallelResult.ocr = r; finish(); }, () => finish());
+          a11yPromise.then(r => { parallelResult.a11y = r; finish(); }, () => finish());
+          // Cancel the deadline timer once both settle so we don't keep the event loop alive
+          Promise.allSettled([ocrPromise, a11yPromise]).then(() => clearTimeout(timer));
+        });
+        const ocrMatch = parallelResult.ocr;
+        const a11yResult = parallelResult.a11y;
+        const parallelTimedOut = parallelResult.timedOut;
 
         // a11y invoke succeeded — best outcome (OS-level click, most reliable)
-        if (a11yResult?.method === 'invoke') {
+        if (a11yResult && (a11yResult as any).method === 'invoke') {
           ctx.a11y.invalidateCache();
           return { text: `Clicked "${target}" via UI Automation (invoke_element)` };
         }
@@ -328,23 +393,55 @@ export function getSmartTools(): ToolDefinition[] {
         // this is a no-op, so the fix is safe across every Windows config
         // and on macOS / Linux (where dpiRatio always returns 1).
         if (ocrMatch) {
+          const m = ocrMatch as NonNullable<typeof ocrMatch>;
+          // Record the OCR hit as a candidate even on the happy path —
+          // if mouseClick throws below, the failure payload still shows
+          // "OCR did find the text, the click itself failed".
+          candidates.push({
+            source: 'ocr',
+            text: m.text,
+            bounds: m.bounds,
+            confidence: m.confidence,
+          });
           const dpi = ctx.desktop.getDpiRatio?.() || 1;
-          const cx = Math.round(ocrMatch.x / dpi);
-          const cy = Math.round(ocrMatch.y / dpi);
-          await ctx.desktop.mouseClick(cx, cy);
+          const cx = Math.round(m.x / dpi);
+          const cy = Math.round(m.y / dpi);
+          try {
+            await ctx.desktop.mouseClick(cx, cy);
+          } catch (err: any) {
+            attempted.push(`ocr_match_click_threw: ${err?.message?.substring(0, 80) || 'unknown'}`);
+            return buildFailure('no_clickable_target', 'ocr_match_click_threw');
+          }
           ctx.a11y.invalidateCache();
-          const warningSuffix = ocrMatch.warning ? `  [WARNING: ${ocrMatch.warning} — verify with read_screen]` : '';
-          return { text: `Clicked "${target}" via OCR (matched "${ocrMatch.text}" at ${cx},${cy}${dpi > 1 ? ` — DPI-corrected from physical ${ocrMatch.x},${ocrMatch.y}` : ''})${warningSuffix}` };
+          const warningSuffix = m.warning ? `  [WARNING: ${m.warning} — verify with read_screen]` : '';
+          return { text: `Clicked "${target}" via OCR (matched "${m.text}" at ${cx},${cy}${dpi > 1 ? ` — DPI-corrected from physical ${m.x},${m.y}` : ''})${warningSuffix}` };
         }
 
         // a11y had bounds but couldn't invoke — coordinate fallback
-        if (a11yResult?.clickPoint) {
-          await ctx.desktop.mouseClick(a11yResult.clickPoint.x, a11yResult.clickPoint.y);
+        if (a11yResult && (a11yResult as any).method === 'bounds') {
+          const a = a11yResult as Extract<NonNullable<typeof a11yResult>, { method: 'bounds' }>;
+          if (a.bounds) {
+            candidates.push({
+              source: 'a11y',
+              text: a.text ?? target,
+              bounds: a.bounds,
+              confidence: null,
+            });
+          }
+          try {
+            await ctx.desktop.mouseClick(a.clickPoint.x, a.clickPoint.y);
+          } catch (err: any) {
+            attempted.push(`a11y_bounds_click_threw: ${err?.message?.substring(0, 80) || 'unknown'}`);
+            return buildFailure('no_clickable_target', 'a11y_bounds_click_threw');
+          }
           ctx.a11y.invalidateCache();
-          return { text: `Clicked "${target}" via a11y bounds (coordinate fallback at ${a11yResult.clickPoint.x},${a11yResult.clickPoint.y})` };
+          return { text: `Clicked "${target}" via a11y bounds (coordinate fallback at ${a.clickPoint.x},${a.clickPoint.y})` };
         }
 
         // Track what was attempted for diagnostics
+        if (parallelTimedOut) {
+          attempted.push('deadline_exceeded_during_ocr_a11y_parallel');
+        }
         if (emptyA11y) {
           attempted.push(`UIA(skipped): app "${appName}" has known traits: emptyAxTree`);
         } else {
@@ -353,7 +450,13 @@ export function getSmartTools(): ToolDefinition[] {
         attempted.push(ocrMatch === null ? 'ocr: no text match found' : 'ocr: unavailable');
 
         // ── Step 2: CDP click (browser content) ──
-        if (isBrowser || await ctx.cdp.isConnected().catch(() => false)) {
+        // Deadline-gated so the outer wall-clock can't fire mid-evaluate.
+        const cdpBudget = remaining();
+        const cdpEligible = isBrowser || (cdpBudget >= MIN_BUDGET_MS &&
+          await ctx.cdp.isConnected().catch(() => false));
+        if (cdpBudget < MIN_BUDGET_MS) {
+          attempted.push('deadline_exceeded_before_cdp');
+        } else if (cdpEligible) {
           try {
             const connected = await ctx.cdp.isConnected();
             if (connected) {
@@ -379,6 +482,8 @@ export function getSmartTools(): ToolDefinition[] {
                 }
                 attempted.push('CDP: no text match found');
               }
+            } else {
+              attempted.push('CDP: not connected');
             }
           } catch (err: any) {
             attempted.push(`CDP: ${err.message?.substring(0, 80)}`);
@@ -387,15 +492,14 @@ export function getSmartTools(): ToolDefinition[] {
           attempted.push(`CDP(skipped): foreground app "${appName}" is not a browser`);
         }
 
-        // All methods failed
-        return {
-          text: `smart_click failed: could not click "${target}" after all fallback methods.\nAttempted:\n${attempted.map((a, i) => `  ${i + 1}. ${a}`).join('\n')}\nDiagnosis:\n  No specific failure pattern detected`,
-          isError: true,
-        };
-        })()]);
-        } catch (err: any) {
-          return { text: err.message, isError: true };
+        // All methods failed. Choose the error code based on whether the
+        // deadline ate any of our subsystems — if so the caller should retry
+        // with a longer timeout; if not, the target is genuinely unfindable.
+        const deadlineHit = parallelTimedOut || remaining() < MIN_BUDGET_MS;
+        if (deadlineHit) {
+          return buildFailure('deadline_exceeded', 'deadline_exceeded');
         }
+        return buildFailure('no_clickable_target', 'all_fallbacks_failed');
       },
     },
 


### PR DESCRIPTION
Fixes #101.

## Summary

Smart-click now returns ranked candidates when all fallbacks fail (instead of just timing out), plus several adjacent fixes surfaced by the live smoke test:

- `smart_click`: when OCR + a11y produce candidates but no high-confidence match, return the ranked candidates in the tool response so the caller can disambiguate
- macOS multi-window: focus + activation now distinguishes the intended window across multiple windows of the same app
- `open_url` tier promotion: was being filtered out of the act-only tier; restored
- a11y description fallback: tools using `description` now fall back to `value`/`title` when the underlying platform leaves `description` empty (windows AX gap)

Plus 3 doc-accuracy fixes from the same smoke test (README runtime claims, doctor's update recommendation, site title).

## Test plan
- [x] `npm test` green locally
- [x] Manual: `smart_click` against the test interface with an ambiguous target returns the candidate list
- [x] macOS multi-window manual verification (focus correct instance)