### PR TITLE
fix(agent): blind-mode rejects raw coordinate clicks without recent a11y selection

### DIFF
--- a/src/__tests__/blind-coord-click-guard.test.ts
+++ b/src/__tests__/blind-coord-click-guard.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the blind-mode raw-coordinate-click guardrail (BUG-D).
+ *
+ * Failure mode: in blind mode (a11y-only, no screenshots) the LLM sometimes
+ * can't find a target in the a11y snapshot — and instead of emitting
+ * `cannot_read`, it starts random-clicking at guessed coordinates
+ * (`click(1280,800)`, `click(1280,600)`, etc). In a live test run, this
+ * advanced an exam-test UI from the landing screen to test #7
+ * ("double-click") before timing out — actual user-visible state damage.
+ *
+ * The fix: in blind mode, `click(x, y)` is refused unless an a11y-aware
+ * selector tool (invoke_element / set_field_value / focus_element /
+ * a11y_*) SUCCEEDED in the last 2 step entries. The refusal consumes one
+ * turn but is surfaced as an ERROR tool_result so the verifier never reads
+ * it as evidence of progress, and the runaway-guard caps retries.
+ *
+ * Mode-gated: hybrid mode is unchanged (it can call screenshot to verify),
+ * and `cannot_read` remains the explicit graceful give-up path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PlatformAdapter, WindowInfo, ScreenshotResult } from '../platform/types';
+import type { ToolUseResult, LLMAssistantBlock } from '../llm/client';
+
+// Mock callLLMWithTools BEFORE importing runAgent so the loop binds to
+// the mock. Each test pushes turn-by-turn behavior into `llmTurnQueue`.
+const llmTurnQueue: ToolUseResult[] = [];
+vi.mock('../llm/client', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../llm/client')>();
+  return {
+    ...orig,
+    callLLMWithTools: vi.fn(async (): Promise<ToolUseResult> => {
+      const next = llmTurnQueue.shift();
+      if (!next) {
+        return { text: '', toolCalls: [], stopReason: 'end_turn', raw: [] };
+      }
+      return next;
+    }),
+  };
+});
+
+import { runAgent } from '../core/agent-loop/agent';
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+const emptyShot = (): ScreenshotResult => ({
+  buffer: Buffer.alloc(0),
+  width: 1920,
+  height: 1080,
+  scaleFactor: 1,
+});
+
+/** Adapter stub — deterministic state, never changes the fingerprint. */
+function makeAdapter(): PlatformAdapter {
+  return {
+    platform: 'win32',
+    init: vi.fn(async () => {}),
+    shutdown: vi.fn(async () => {}),
+    checkPermissions: vi.fn(async () => ({ input: true, accessibility: true, screenRecording: true })),
+    requestPermissions: vi.fn(async () => ({ input: true, accessibility: true, screenRecording: true })),
+    getScreenSize: vi.fn(async () => ({
+      logicalWidth: 1920, logicalHeight: 1080,
+      physicalWidth: 1920, physicalHeight: 1080,
+      dpiRatio: 1,
+    })),
+    screenshot: vi.fn(async () => emptyShot()),
+    screenshotRegion: vi.fn(async () => emptyShot()),
+    listWindows: vi.fn(async (): Promise<WindowInfo[]> => [
+      { processId: 100, processName: 'notepad', title: 'Untitled - Notepad', bounds: { x: 0, y: 0, width: 800, height: 600 }, isMinimized: false },
+    ]),
+    getActiveWindow: vi.fn(async () => ({
+      processId: 100, processName: 'notepad', title: 'Untitled - Notepad',
+      bounds: { x: 0, y: 0, width: 800, height: 600 }, isMinimized: false,
+    })),
+    focusWindow: vi.fn(async () => true),
+    maximizeWindow: vi.fn(async () => {}),
+    minimizeWindow: vi.fn(async () => {}),
+    restoreWindow: vi.fn(async () => {}),
+    closeWindow: vi.fn(async () => {}),
+    resizeWindow: vi.fn(async () => {}),
+    listDisplays: vi.fn(async () => [{ id: 0, primary: true, bounds: { x: 0, y: 0, width: 1920, height: 1080 }, workArea: { x: 0, y: 0, width: 1920, height: 1080 }, scaleFactor: 1 }]),
+    getUiTree: vi.fn(async () => []),
+    findElements: vi.fn(async () => []),
+    getFocusedElement: vi.fn(async () => null),
+    invokeElement: vi.fn(async () => ({ success: true })),
+    mouseClick: vi.fn(async () => {}),
+    mouseMove: vi.fn(async () => {}),
+    mouseDrag: vi.fn(async () => {}),
+    mouseScroll: vi.fn(async () => {}),
+    typeText: vi.fn(async () => {}),
+    keyPress: vi.fn(async () => {}),
+    readClipboard: vi.fn(async () => ''),
+    writeClipboard: vi.fn(async () => {}),
+    openApp: vi.fn(async () => ({})),
+    launchApp: vi.fn(async () => ({})),
+    cdpDriver: undefined,
+  } as unknown as PlatformAdapter;
+}
+
+/** Convenience: LLM turn requesting a single tool call. */
+function turnCall(name: string, args: Record<string, unknown> = {}): ToolUseResult {
+  const id = `c_${Math.random().toString(36).slice(2, 8)}`;
+  const raw: LLMAssistantBlock[] = [
+    { type: 'tool_use', id, name, input: args },
+  ];
+  return {
+    text: '',
+    toolCalls: [{ id, name, args }],
+    stopReason: 'tool_use',
+    raw,
+  };
+}
+
+const LLM_CONFIG = {
+  text: { baseUrl: 'http://stub', model: 'stub-text', apiKey: 'k', isAnthropic: false },
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe('blind-mode raw-coordinate-click guardrail', () => {
+  beforeEach(() => {
+    llmTurnQueue.length = 0;
+  });
+
+  // T1: blind mode + click(100,200) with no prior a11y selection → refused,
+  // next turn still allowed (refusal consumes one turn, doesn't terminate).
+  it('T1: refuses click(x,y) in blind mode when no a11y element was recently selected', async () => {
+    // Turn 1: agent guesses a coordinate click with no prior a11y resolution.
+    llmTurnQueue.push(turnCall('click', { x: 100, y: 200 }));
+    // Turn 2: agent recovers by calling cannot_read (the prompted escape).
+    llmTurnQueue.push(turnCall('cannot_read', { reason: 'a11y snapshot has nothing matching' }));
+
+    const adapter = makeAdapter();
+    const result = await runAgent(
+      { task: 'click the button', mode: 'blind', maxTurns: 10 },
+      { adapter, llm: LLM_CONFIG },
+    );
+
+    // The refused click consumed a turn (logged as step).
+    expect(result.steps.length).toBeGreaterThanOrEqual(2);
+    const refusedStep = result.steps[0];
+    expect(refusedStep.toolName).toBe('click');
+    expect(refusedStep.result.success).toBe(false);
+    expect(refusedStep.result.text).toMatch(/blind.?mode coord.?click refused|coordinate click rejected/i);
+
+    // CRITICAL: the underlying platform mouseClick was NEVER called — the
+    // bug was that guessed coordinates reached the OS and damaged screen state.
+    expect((adapter.mouseClick as any).mock.calls.length).toBe(0);
+
+    // The agent's next turn was allowed (the guard doesn't terminate the rung).
+    expect(result.steps[1].toolName).toBe('cannot_read');
+    expect(result.exit).toBe('cannot_read');
+  });
+
+  // T2: blind mode + a11y-aware click on turn N, then click(x,y) on turn N+1
+  // → ALLOWED (recent a11y selection covers the coord-click fallback).
+  it('T2: allows click(x,y) in blind mode when an a11y selector succeeded recently', async () => {
+    // Turn 1: invoke_element succeeds (adapter stub returns success:true).
+    llmTurnQueue.push(turnCall('invoke_element', { name: 'Begin Exam' }));
+    // Turn 2: coord-click fallback (e.g. a11y action didn't visibly fire).
+    llmTurnQueue.push(turnCall('click', { x: 100, y: 200 }));
+    // Turn 3: declare done.
+    llmTurnQueue.push(turnCall('done', { evidence: 'exam landing screen replaced by test 1 prompt' }));
+
+    const adapter = makeAdapter();
+    const result = await runAgent(
+      { task: 'start the exam', mode: 'blind', maxTurns: 10 },
+      { adapter, llm: LLM_CONFIG },
+    );
+
+    // The click went through to the platform — proves the guard did NOT fire.
+    expect((adapter.mouseClick as any).mock.calls.length).toBe(1);
+    expect((adapter.mouseClick as any).mock.calls[0][0]).toBe(100);
+    expect((adapter.mouseClick as any).mock.calls[0][1]).toBe(200);
+
+    expect(result.steps[0].toolName).toBe('invoke_element');
+    expect(result.steps[0].result.success).toBe(true);
+    expect(result.steps[1].toolName).toBe('click');
+    expect(result.steps[1].result.success).toBe(true);
+    expect(result.exit).toBe('done');
+  });
+
+  // T3: hybrid mode + click(x,y) with no a11y selection → ALLOWED. The
+  // guard is mode-gated; hybrid mode has screenshot as the escape hatch.
+  it('T3: does NOT fire in hybrid mode', async () => {
+    llmTurnQueue.push(turnCall('click', { x: 100, y: 200 }));
+    llmTurnQueue.push(turnCall('done', { evidence: 'screen advanced to expected next view' }));
+
+    const adapter = makeAdapter();
+    const result = await runAgent(
+      { task: 'click the button', mode: 'hybrid', maxTurns: 10 },
+      { adapter, llm: LLM_CONFIG },
+    );
+
+    // In hybrid the click reaches the platform — the guard is blind-mode-only.
+    expect((adapter.mouseClick as any).mock.calls.length).toBe(1);
+    expect(result.steps[0].toolName).toBe('click');
+    expect(result.steps[0].result.success).toBe(true);
+    expect(result.exit).toBe('done');
+  });
+
+  // T4: blind mode + cannot_read → ALLOWED, marked as graceful give-up.
+  // Confirms the documented escape path still works after the guard ships.
+  it('T4: allows cannot_read as the graceful blind-mode give-up', async () => {
+    llmTurnQueue.push(turnCall('cannot_read', { reason: 'a11y snapshot is empty' }));
+
+    const adapter = makeAdapter();
+    const result = await runAgent(
+      { task: 'find and click the button', mode: 'blind', maxTurns: 10 },
+      { adapter, llm: LLM_CONFIG },
+    );
+
+    expect(result.steps.length).toBe(1);
+    expect(result.steps[0].toolName).toBe('cannot_read');
+    expect(result.exit).toBe('cannot_read');
+    // cannot_read is a terminal that does NOT call mouseClick.
+    expect((adapter.mouseClick as any).mock.calls.length).toBe(0);
+  });
+});

--- a/src/core/agent-loop/agent.ts
+++ b/src/core/agent-loop/agent.ts
@@ -528,6 +528,64 @@ export async function runAgent(input: AgentInput, deps: AgentDeps): Promise<Agen
           }
         }
 
+        // 5a'''. BLIND-MODE RAW-COORDINATE-CLICK GUARD.
+        //
+        // Failure mode (BUG-D): in blind mode the LLM sometimes can't locate
+        // a target in the a11y snapshot and, instead of emitting `cannot_read`,
+        // starts random-clicking at guessed coordinates like click(1280,800).
+        // In a live run, this advanced an exam-test UI from the landing screen
+        // through several screens — real user-visible state damage — before
+        // the verifier even ran. The verifier alone (confidence threshold) is
+        // not a sufficient safety net because a more confident model could
+        // produce false-positive success.
+        //
+        // The guard: in blind mode, refuse `click(x, y)` unless an a11y-aware
+        // selector tool (invoke_element / set_field_value / focus_element /
+        // a11y_select / a11y_toggle / a11y_expand / a11y_collapse /
+        // wait_for_element) SUCCEEDED in the last A11Y_RECENCY turns. That
+        // tight window covers the legitimate "I just located the element by
+        // a11y; coord-click as fallback" pattern while rejecting guesses.
+        //
+        // Refusal consumes one turn (the runaway-guard above caps infinite
+        // retries) and routes the agent to either call `cannot_read` (the
+        // explicit blind→vision escape) or use an a11y-aware variant first.
+        // Refusal is NOT a tool success — it surfaces as an error in
+        // tool_result so the verifier won't read it as evidence of progress.
+        if (call.name === 'click' && input.mode === 'blind') {
+          const A11Y_RECENCY = 2; // last N step entries
+          const A11Y_RESOLVERS = new Set([
+            'invoke_element', 'set_field_value', 'focus_element',
+            'a11y_select', 'a11y_toggle', 'a11y_expand', 'a11y_collapse',
+            'wait_for_element', 'find_element',
+          ]);
+          const recentA11y = steps.slice(-A11Y_RECENCY).some(s =>
+            A11Y_RESOLVERS.has(s.toolName) && s.result.success,
+          );
+          if (!recentA11y) {
+            log.warn('agent.blind_coord_click.refused', {
+              turn,
+              args: compactArgs(call.args),
+              reason: 'no recent successful a11y selection',
+              recency: A11Y_RECENCY,
+            });
+            toolResults.push({
+              id: call.id,
+              text: 'raw coordinate click rejected in blind mode: no a11y element was selected in the last 2 turns, so (x,y) is a guess. Either (a) call invoke_element / focus_element / set_field_value with the element\'s a11y name from the snapshot, or (b) emit cannot_read to escalate to vision and get pixel evidence first. Guessing coordinates from a text snapshot can navigate the app to an unintended state.',
+              isError: true,
+            });
+            steps.push({
+              turn,
+              toolName: call.name,
+              toolArgs: call.args,
+              result: { success: false, text: 'blind-mode coord-click refused (no recent a11y selection)' },
+              durationMs: Date.now() - turnStart,
+              fingerprintChanged: false,
+              thought: llmResult.text,
+            });
+            continue;
+          }
+        }
+
         // 5b. Log and execute.
         log.info(EVENTS.AGENT_TOOL_CALL, { turn, tool: call.name, args: compactArgs(call.args) });
         const toolStart = Date.now();


### PR DESCRIPTION
## The bug (BUG-D)

In **blind mode** (a11y-only, no screenshots) the LLM sometimes can't find a target in the a11y snapshot — and instead of emitting `cannot_read`, it starts random-clicking at guessed coordinates: `click(1280,800)`, `click(1280,600)`, `type("begin exam")`, `key(Tab)`, etc.

In a live test run, this advanced a test-interface exam UI from the **landing screen all the way to test #7 ("double-click")** before the rung timed out — actual user-visible state damage. The verifier (confidence 0.65 in that run) is **not** a sufficient safety net because a more confident model would have produced false-positive `success: true`.

## The fix

Approach **(a)** from the bug report: stop the damage at the source rather than after the fact.

In blind mode, `click(x, y)` is **refused** unless an a11y-aware selector tool succeeded in the last 2 step entries. The allow-list:

- `invoke_element` / `set_field_value` / `focus_element`
- `a11y_select` / `a11y_toggle` / `a11y_expand` / `a11y_collapse`
- `wait_for_element` / `find_element`

A 2-turn recency window covers the legitimate "I just located the element by a11y; coord-click as fallback" pattern while rejecting raw guesses.

**Why this works as a safety net:**
- The refusal returns a structured `tool_result` (with `is_error: true`) so the verifier never reads it as evidence of progress.
- The platform `mouseClick` is never invoked — the OS sees nothing.
- The refusal consumes one turn (the existing runaway-guard at the top of the dispatch loop caps infinite retries to 3 in 6 turns).
- The refusal message tells the agent the two legitimate next moves: call an a11y selector first, or emit `cannot_read` to escalate to vision.

**Mode-gated.** Hybrid and vision are unchanged:
- Hybrid mode already has `screenshot()` as the explicit escape hatch.
- Vision mode seeds an initial screenshot, so coords are grounded in pixels.

**Scope.** No changes to the verifier, OCR, smart_click, or the meaning of `mode`. Only `click` (the canonical raw-coord entry point cited in the bug report) is guarded — `drag` and `scroll` need explicit x/y by design and aren't where hallucinations cluster.

## Insertion point

The guard lives in `src/core/agent-loop/agent.ts` as block **5a'''** in the tool-dispatch loop, right next to the existing `runaway_guard` (5a') and `cannot_read` soft-guard (5a''). The same `steps[]` history those guards already consult is what tracks the recent a11y selection — no new state, no new fields on `AgentInput`.

## Tests

New file: `src/__tests__/blind-coord-click-guard.test.ts`. Pattern mirrors the existing `run-agent.test.ts` (mock `callLLMWithTools`, deterministic adapter stub, queue turns).

| | Scenario | Expected | Status |
|---|---|---|---|
| **T1** | blind + `click(100,200)` with no prior a11y selection | refused with structured tool-result; `mouseClick` never called; agent's next turn (`cannot_read`) is allowed | pass |
| **T2** | blind + `invoke_element("Begin Exam")` on turn N, then `click(100,200)` on N+1 | allowed; `mouseClick` invoked with `(100, 200)` | pass |
| **T3** | hybrid + `click(100,200)` with no a11y selection | allowed (guard is blind-mode-only) | pass |
| **T4** | blind + `cannot_read` | allowed; graceful give-up exit | pass |

## Verification

- `npm run typecheck` clean
- `npm run typecheck:tests` clean
- `npm run build` clean
- `npm run test:ci` — **52 test files, 816 passed, 0 failed**

## Test plan

- [x] Build green
- [x] All existing tests still green
- [x] T1–T4 regression tests pass
- [ ] Re-run the live exam-test scenario from BUG-D to confirm the symptom is gone (no longer advances past landing screen when the agent can't see "Begin Exam" in a11y)
