### PR TITLE
fix(agent): CLI flags now reach the runtime pipeline config

### DIFF
--- a/src/__tests__/load-pipeline-config-overlay.test.ts
+++ b/src/__tests__/load-pipeline-config-overlay.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression tests for the CLI-flag → pipeline-config overlay path.
+ *
+ * Bug context (fix/cli-flags-ignored-by-agent-loop):
+ *   `clawdcursor agent --provider ollama --base-url X --text-model Y --api-key Z`
+ *   would print "Using externally configured models: text=Y | vision=" but
+ *   then the agent runtime read from loadPipelineConfig() which only looked
+ *   at .clawdcursor-config.json. With no file on disk, the pipeline started
+ *   with models=text=off and every ladder rung short-circuited.
+ *
+ * These tests assert that when resolveConfig() returns a ResolvedConfig with
+ * CLI-sourced fields, passing that overlay to loadPipelineConfig() produces
+ * a PipelineConfig whose layer2/layer3 carry the CLI-supplied values — even
+ * when no .clawdcursor-config.json exists.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { resolveConfig } from '../llm/config';
+import { loadPipelineConfig } from '../surface/doctor';
+import { getPackageRoot } from '../paths';
+
+const CONFIG_FILE = '.clawdcursor-config.json';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pipeline-overlay-test-'));
+}
+
+// loadPipelineConfig() reads from `<packageRoot>/.clawdcursor-config.json`
+// first and falls back to `<cwd>/.clawdcursor-config.json`. We snapshot and
+// restore that file so any pre-existing real config is preserved across
+// the test run, and the disk read is guaranteed to find "no file" by
+// default.
+let _savedPkgConfig: string | null = null;
+const _pkgConfigPath = path.join(getPackageRoot(), CONFIG_FILE);
+
+function clearPkgConfig(): void {
+  if (_savedPkgConfig !== null) {
+    fs.writeFileSync(_pkgConfigPath, _savedPkgConfig);
+    _savedPkgConfig = null;
+  } else if (fs.existsSync(_pkgConfigPath)) {
+    fs.unlinkSync(_pkgConfigPath);
+  }
+}
+
+beforeEach(() => {
+  // Snapshot any existing pkg-root config so tests start from a clean slate.
+  if (fs.existsSync(_pkgConfigPath)) {
+    _savedPkgConfig = fs.readFileSync(_pkgConfigPath, 'utf-8');
+    fs.unlinkSync(_pkgConfigPath);
+  }
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  clearPkgConfig();
+  vi.restoreAllMocks();
+});
+
+describe('loadPipelineConfig(overlay) — CLI flags reach the runtime', () => {
+  /**
+   * Primary regression: this is the live-test scenario from BUG-A.
+   * With NO .clawdcursor-config.json and CLI flags supplying provider +
+   * base-url + text-model + api-key, the runtime MUST see those flags
+   * via loadPipelineConfig — otherwise the pipeline boots with
+   * `models=text=off vision=disabled` and every rung short-circuits.
+   */
+  it('synthesizes a PipelineConfig from CLI flags when no config file exists', () => {
+    const tmpDir = makeTmpDir();
+    const resolved = resolveConfig({
+      cliFlags: {
+        provider: 'ollama',
+        baseUrl: 'http://localhost:11434/v1',
+        textModel: 'minimax-m2.5:cloud',
+        apiKey: 'cli-key-xyz',
+      },
+      // Point at non-existent paths so disk has no .clawdcursor-config.json
+      projectConfigPath: path.join(tmpDir, 'nope-project.json'),
+      userConfigPath: path.join(tmpDir, 'nope-user.json'),
+      envOverride: {},
+    });
+
+    expect(resolved.source.model).toBe('cli');
+    expect(resolved.source.baseUrl).toBe('cli');
+    expect(resolved.source.apiKey).toBe('cli');
+
+    const pipeline = loadPipelineConfig(resolved);
+
+    // The whole point of the fix: CLI flags MUST reach loadPipelineConfig
+    // even with no disk config.
+    expect(pipeline).not.toBeNull();
+    expect(pipeline!.layer2.model).toBe('minimax-m2.5:cloud');
+    expect(pipeline!.layer2.baseUrl).toBe('http://localhost:11434/v1');
+    expect(pipeline!.layer2.apiKey).toBe('cli-key-xyz');
+    expect(pipeline!.layer2.enabled).toBe(true);
+    expect(pipeline!.providerKey).toBe('ollama');
+  });
+
+  it('passes CLI text-model through even when only --text-model + --base-url + --api-key supplied (no --provider)', () => {
+    const tmpDir = makeTmpDir();
+    const resolved = resolveConfig({
+      cliFlags: {
+        baseUrl: 'http://localhost:11434/v1',
+        textModel: 'qwen2.5:7b',
+        apiKey: 'sk-test',
+      },
+      projectConfigPath: path.join(tmpDir, 'nope-project.json'),
+      userConfigPath: path.join(tmpDir, 'nope-user.json'),
+      envOverride: {},
+    });
+
+    const pipeline = loadPipelineConfig(resolved);
+
+    expect(pipeline).not.toBeNull();
+    expect(pipeline!.layer2.model).toBe('qwen2.5:7b');
+    expect(pipeline!.layer2.baseUrl).toBe('http://localhost:11434/v1');
+    expect(pipeline!.layer2.enabled).toBe(true);
+  });
+
+  it('returns null when no overlay AND no disk config (the original broken state, preserved as default for non-overlay callers)', () => {
+    const pipeline = loadPipelineConfig(undefined);
+    expect(pipeline).toBeNull();
+  });
+
+  it('returns null when overlay has no CLI-sourced fields and no disk config', () => {
+    const tmpDir = makeTmpDir();
+    const resolved = resolveConfig({
+      cliFlags: {}, // empty — everything falls through to default
+      projectConfigPath: path.join(tmpDir, 'nope-project.json'),
+      userConfigPath: path.join(tmpDir, 'nope-user.json'),
+      envOverride: {},
+    });
+    const pipeline = loadPipelineConfig(resolved);
+    expect(pipeline).toBeNull();
+  });
+
+  it('vision flags propagate when supplied (layer3 enabled with CLI --vision-model + --base-url)', () => {
+    const tmpDir = makeTmpDir();
+    const resolved = resolveConfig({
+      cliFlags: {
+        baseUrl: 'http://localhost:11434/v1',
+        textModel: 'qwen2.5:7b',
+        visionModel: 'llava:13b',
+        apiKey: 'sk-test',
+      },
+      projectConfigPath: path.join(tmpDir, 'nope-project.json'),
+      userConfigPath: path.join(tmpDir, 'nope-user.json'),
+      envOverride: {},
+    });
+
+    const pipeline = loadPipelineConfig(resolved);
+    expect(pipeline).not.toBeNull();
+    expect(pipeline!.layer3.model).toBe('llava:13b');
+    expect(pipeline!.layer3.baseUrl).toBe('http://localhost:11434/v1');
+    expect(pipeline!.layer3.enabled).toBe(true);
+  });
+});

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -141,7 +141,13 @@ export class Agent {
       const { Pipeline } = await import('./pipeline');
       const { getPlatform } = await import('../platform');
       const adapter = await getPlatform();
-      const pipelineConfig = loadPipelineConfig();
+      // Pass the resolved CLI overlay so flags supplied at boot time
+      // (--text-model, --base-url, --api-key, ...) are honoured even
+      // when no .clawdcursor-config.json exists on disk. Without this
+      // the runtime ignores CLI flags and falls back to disk-only,
+      // producing `models=text=off vision=disabled` and short-circuiting
+      // every ladder rung.
+      const pipelineConfig = loadPipelineConfig(this.resolvedConfig);
 
       const hasTextModel   = !!(pipelineConfig?.layer2.model && pipelineConfig.layer2.baseUrl);
       const hasVisionModel = !!(pipelineConfig?.layer3?.model && pipelineConfig?.layer3?.baseUrl);

--- a/src/surface/cli.ts
+++ b/src/surface/cli.ts
@@ -246,8 +246,19 @@ async function runAgentMode(opts: AgentModeOpts): Promise<void> {
   // ── First-run auto-setup — best-effort, never fatal. ──
   // If no AI providers are found we still boot: the MCP tool surface
   // works fine without an LLM (the host's brain drives it).
+  //
+  // Skip auto-detect entirely when CLI flags already supply a usable
+  // model wiring — otherwise we'd print the misleading "No AI providers
+  // found — booting in tools-only mode" line moments before "Using
+  // externally configured models: text=X" (BUG-A: contradictory boot
+  // banners). The CLI-flag path knows its own answer.
   const configPath = path.join(getPackageRoot(), '.clawdcursor-config.json');
-  if (!forceNoLlm && !fs.existsSync(configPath)) {
+  const cliSuppliesLlm = Boolean(
+    opts.apiKey
+    || (opts.baseUrl && (opts.textModel || opts.visionModel || opts.model))
+    || ((opts.textModel || opts.visionModel || opts.model) && opts.provider),
+  );
+  if (!forceNoLlm && !cliSuppliesLlm && !fs.existsSync(configPath)) {
     console.log(`${e('🔍', '*')} First run — auto-detecting AI providers...\n`);
     const { quickSetup } = await import('./doctor');
     const pipeline = await quickSetup();
@@ -440,7 +451,9 @@ async function runAgentMode(opts: AgentModeOpts): Promise<void> {
 
     if (llmAvailable) {
       const { loadPipelineConfig } = await import('./doctor');
-      const pipelineConfig = loadPipelineConfig();
+      // Pass the resolved CLI overlay so the validation/print path sees the
+      // same pipeline config the agent runtime will use.
+      const pipelineConfig = loadPipelineConfig(resolved);
       if (pipelineConfig && pipelineConfig.layer2.enabled) {
         try {
           const { callTextLLMDirect } = await import('../llm/client');

--- a/src/surface/doctor.ts
+++ b/src/surface/doctor.ts
@@ -35,7 +35,8 @@ import type {
 } from '../llm/providers';
 import { DEFAULT_CONFIG } from '../types';
 import { getPackageRoot } from '../paths';
-import { resolveApiConfig } from '../llm/credentials';
+import { resolveApiConfig, inferProviderFromBaseUrl } from '../llm/credentials';
+import type { ResolvedConfig } from '../llm/config';
 import { callVisionLLMDirect } from '../llm/client';
 import { hasConsent } from './onboarding';
 import { checkPermissionsQuick, requestPermissions, isMacOS } from '../platform/native-helper';
@@ -1633,7 +1634,7 @@ function resolveProviderApiKey(providerKey: string, fallbackApiKey?: string): st
   return fallbackApiKey || '';
 }
 
-export function loadPipelineConfig(): PipelineConfig | null {
+export function loadPipelineConfig(overlay?: ResolvedConfig | null): PipelineConfig | null {
   const pkgDir = getPackageRoot();
   let configPath = path.join(pkgDir, CONFIG_FILE);
 
@@ -1641,55 +1642,175 @@ export function loadPipelineConfig(): PipelineConfig | null {
     configPath = path.join(process.cwd(), CONFIG_FILE);
   }
 
+  // Read on-disk config (may be null if no file exists).
+  let diskConfig: PipelineConfig | null = null;
   try {
-    if (!fs.existsSync(configPath)) return null;
-    const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const providerKey = raw.provider || 'ollama';
+    if (fs.existsSync(configPath)) {
+      const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      const providerKey = raw.provider || 'ollama';
+      const provider = PROVIDERS[providerKey] || PROVIDERS['ollama'];
+      // Resolve API key: check provider-scoped env vars FIRST, then fall back to
+      // generic resolution. This prevents OpenClaw auth-profiles (e.g. a stale
+      // Anthropic key) from overriding the correct provider-specific key.
+      const scopedEnvKey = (PROVIDER_ENV_VARS[providerKey] || [])
+        .map(k => process.env[k])
+        .find(v => v && v.length > 0) || '';
+      const resolvedDefault = resolveApiConfig();
+      const defaultApiKey = scopedEnvKey || resolvedDefault.apiKey;
+
+      // Support both v0.7.5+ (textModel/visionModel) and legacy (layer2/layer3) field names
+      const layer2Data = raw.pipeline?.textModel ?? raw.pipeline?.layer2;
+      const layer3Data = raw.pipeline?.visionModel ?? raw.pipeline?.layer3;
+
+      const layer2BaseUrl = layer2Data?.baseUrl ?? provider.baseUrl;
+      const layer3BaseUrl = layer3Data?.baseUrl ?? provider.baseUrl;
+      const layer2ProviderKey = layer2Data?.provider || providerKey;
+      const layer3ProviderKey = layer3Data?.provider || providerKey;
+      const layer3ComputerUse = layer3Data?.computerUse ?? false;
+
+      // Resolve API keys PER LAYER based on each layer's provider.
+      // Mixed pipelines (e.g., Kimi text + Anthropic vision) need different keys.
+      const layer2ApiKey = resolveProviderApiKey(layer2ProviderKey, defaultApiKey);
+      const layer3ApiKey = resolveProviderApiKey(layer3ProviderKey, defaultApiKey);
+
+      diskConfig = {
+        provider,
+        providerKey,
+        apiKey: layer2ApiKey, // primary key = text layer key (most LLM calls use text)
+        layer1: true,
+        layer2: {
+          enabled: layer2Data?.enabled ?? false,
+          model: layer2Data?.model ?? provider.textModel,
+          baseUrl: layer2BaseUrl,
+          apiKey: layer2ApiKey, // per-layer key for mixed-provider pipelines
+        },
+        layer3: {
+          enabled: layer3Data?.enabled ?? false,
+          model: layer3Data?.model ?? provider.visionModel,
+          baseUrl: layer3BaseUrl,
+          computerUse: layer3ComputerUse,
+          apiKey: layer3ApiKey, // always resolve per-layer, not just for CU
+        },
+      };
+    }
+  } catch {
+    diskConfig = null;
+  }
+
+  // No CLI overlay → just return whatever (or null) the disk gave us.
+  if (!overlay) return diskConfig;
+
+  return applyCliOverlay(diskConfig, overlay);
+}
+
+/**
+ * Overlay CLI-sourced fields from a ResolvedConfig onto a PipelineConfig.
+ *
+ * If `disk` is null but the overlay supplies enough to construct a pipeline
+ * (a text-model+base-url OR a vision-model+base-url with a CLI source),
+ * a minimal PipelineConfig is synthesized so the agent runtime sees the
+ * flags supplied on the command line.
+ *
+ * Only fields whose `source` tag is 'cli' override the disk values; this
+ * preserves the canonical precedence ladder. Project/user/env-sourced
+ * values from `ResolvedConfig` are NOT applied here — those flow through
+ * the existing disk-config path and provider-scoped env resolution.
+ */
+function applyCliOverlay(
+  disk: PipelineConfig | null,
+  overlay: ResolvedConfig,
+): PipelineConfig | null {
+  const src = overlay.source;
+  const textBaseFromCli   = src.textBaseUrl   === 'cli' ? overlay.textBaseUrl
+                          : src.baseUrl       === 'cli' ? overlay.baseUrl
+                          : undefined;
+  const textModelFromCli  = src.model         === 'cli' ? overlay.model         : undefined;
+  const textApiFromCli    = src.textApiKey    === 'cli' ? overlay.textApiKey
+                          : src.apiKey        === 'cli' ? overlay.apiKey
+                          : undefined;
+  const visionBaseFromCli = src.visionBaseUrl === 'cli' ? overlay.visionBaseUrl
+                          : src.baseUrl       === 'cli' ? overlay.baseUrl
+                          : undefined;
+  const visionModelFromCli= src.visionModel   === 'cli' ? overlay.visionModel   : undefined;
+  const visionApiFromCli  = src.visionApiKey  === 'cli' ? overlay.visionApiKey
+                          : src.apiKey        === 'cli' ? overlay.apiKey
+                          : undefined;
+  const providerFromCli   = src.provider      === 'cli' ? overlay.provider      : undefined;
+
+  const anyCli = textBaseFromCli || textModelFromCli || textApiFromCli
+              || visionBaseFromCli || visionModelFromCli || visionApiFromCli
+              || providerFromCli;
+
+  if (!disk && !anyCli) return null;
+
+  // Synthesize a minimal pipeline if no disk config exists.
+  if (!disk) {
+    const layer2BaseUrl = textBaseFromCli || '';
+    const layer3BaseUrl = visionBaseFromCli || '';
+    const providerKey = providerFromCli
+                      || inferProviderFromBaseUrl(layer2BaseUrl || layer3BaseUrl)
+                      || 'ollama';
     const provider = PROVIDERS[providerKey] || PROVIDERS['ollama'];
-    // Resolve API key: check provider-scoped env vars FIRST, then fall back to
-    // generic resolution. This prevents OpenClaw auth-profiles (e.g. a stale
-    // Anthropic key) from overriding the correct provider-specific key.
-    const scopedEnvKey = (PROVIDER_ENV_VARS[providerKey] || [])
-      .map(k => process.env[k])
-      .find(v => v && v.length > 0) || '';
-    const resolvedDefault = resolveApiConfig();
-    const defaultApiKey = scopedEnvKey || resolvedDefault.apiKey;
-
-    // Support both v0.7.5+ (textModel/visionModel) and legacy (layer2/layer3) field names
-    const layer2Data = raw.pipeline?.textModel ?? raw.pipeline?.layer2;
-    const layer3Data = raw.pipeline?.visionModel ?? raw.pipeline?.layer3;
-
-    const layer2BaseUrl = layer2Data?.baseUrl ?? provider.baseUrl;
-    const layer3BaseUrl = layer3Data?.baseUrl ?? provider.baseUrl;
-    const layer2ProviderKey = layer2Data?.provider || providerKey;
-    const layer3ProviderKey = layer3Data?.provider || providerKey;
-    const layer3ComputerUse = layer3Data?.computerUse ?? false;
-
-    // Resolve API keys PER LAYER based on each layer's provider.
-    // Mixed pipelines (e.g., Kimi text + Anthropic vision) need different keys.
-    const layer2ApiKey = resolveProviderApiKey(layer2ProviderKey, defaultApiKey);
-    const layer3ApiKey = resolveProviderApiKey(layer3ProviderKey, defaultApiKey);
-
+    const layer2Model = textModelFromCli || '';
+    const layer3Model = visionModelFromCli || '';
+    const layer2ApiKey = textApiFromCli || '';
+    const layer3ApiKey = visionApiFromCli || layer2ApiKey;
     return {
       provider,
       providerKey,
-      apiKey: layer2ApiKey, // primary key = text layer key (most LLM calls use text)
+      apiKey: layer2ApiKey,
       layer1: true,
       layer2: {
-        enabled: layer2Data?.enabled ?? false,
-        model: layer2Data?.model ?? provider.textModel,
+        enabled: Boolean(layer2Model && layer2BaseUrl),
+        model: layer2Model,
         baseUrl: layer2BaseUrl,
-        apiKey: layer2ApiKey, // per-layer key for mixed-provider pipelines
+        apiKey: layer2ApiKey,
       },
       layer3: {
-        enabled: layer3Data?.enabled ?? false,
-        model: layer3Data?.model ?? provider.visionModel,
+        enabled: Boolean(layer3Model && layer3BaseUrl),
+        model: layer3Model,
         baseUrl: layer3BaseUrl,
-        computerUse: layer3ComputerUse,
-        apiKey: layer3ApiKey, // always resolve per-layer, not just for CU
+        computerUse: false,
+        apiKey: layer3ApiKey,
       },
     };
-  } catch {
-    return null;
   }
+
+  // Disk config exists — overlay CLI fields on top of it. Each layer's
+  // `enabled` flag flips to true once the layer has both a model and a
+  // base URL (CLI flags can complete a partial disk config the same way
+  // an explicit `enabled: true` would).
+  const layer2BaseUrl = textBaseFromCli   ?? disk.layer2.baseUrl;
+  const layer2Model   = textModelFromCli  ?? disk.layer2.model;
+  const layer2ApiKey  = textApiFromCli    ?? disk.layer2.apiKey ?? disk.apiKey;
+  const layer3BaseUrl = visionBaseFromCli ?? disk.layer3.baseUrl;
+  const layer3Model   = visionModelFromCli?? disk.layer3.model;
+  const layer3ApiKey  = visionApiFromCli  ?? disk.layer3.apiKey ?? disk.apiKey;
+
+  const layer2Enabled = disk.layer2.enabled || Boolean((textModelFromCli || textBaseFromCli) && layer2Model && layer2BaseUrl);
+  const layer3Enabled = disk.layer3.enabled || Boolean((visionModelFromCli || visionBaseFromCli) && layer3Model && layer3BaseUrl);
+
+  const providerKey = providerFromCli ?? disk.providerKey;
+  const provider = providerFromCli ? (PROVIDERS[providerFromCli] || disk.provider) : disk.provider;
+
+  return {
+    ...disk,
+    provider,
+    providerKey,
+    apiKey: layer2ApiKey,
+    layer2: {
+      ...disk.layer2,
+      enabled: layer2Enabled,
+      model: layer2Model,
+      baseUrl: layer2BaseUrl,
+      apiKey: layer2ApiKey,
+    },
+    layer3: {
+      ...disk.layer3,
+      enabled: layer3Enabled,
+      model: layer3Model,
+      baseUrl: layer3BaseUrl,
+      apiKey: layer3ApiKey,
+    },
+  };
 }


### PR DESCRIPTION
## Bug

`clawdcursor agent --provider ollama --base-url X --text-model Y --api-key Z` boots successfully and prints

```
✅ Using externally configured models: text=minimax-m2.5:cloud | vision=
```

…but moments later the pipeline starts with `models=text=off vision=disabled` and every ladder rung (router → blind → hybrid → vision) short-circuits with `no_text_model` / `vision_disabled`. The agent is unusable without a `.clawdcursor-config.json` file even though the CLI flags were supplied.

## Root cause

`src/llm/config.ts` `resolveConfig()` correctly reads the CLI flags and is what prints the banner. The agent runtime, however, reads from `src/surface/doctor.ts` `loadPipelineConfig()`, which only consulted `.clawdcursor-config.json` — it never saw the CLI flags. So the disk-only view diverged from the resolved view.

## Fix

- `loadPipelineConfig(overlay?: ResolvedConfig)` now accepts an optional `ResolvedConfig` overlay. Fields whose `source === 'cli'` override the disk values, and when no disk config exists a minimal `PipelineConfig` is synthesized from the CLI flags. Precedence is preserved end-to-end: **CLI > project > user > env > autodetect > default**.
- `src/core/agent.ts` passes `this.resolvedConfig` into `loadPipelineConfig` at boot.
- `src/surface/cli.ts` post-listen banner also passes the overlay so the validation/print path matches the runtime view.
- `src/surface/cli.ts` first-run auto-setup is skipped when CLI flags already supply a usable LLM wiring (fixes the contradictory banner subitem).

## Before / after — boot logs

**Before** (live test, `--provider ollama --base-url … --text-model minimax-m2.5:cloud --api-key …`):
```
ℹ️  No AI providers found — booting in tools-only mode.
…
✅ Using externally configured models: text=minimax-m2.5:cloud | vision=
…
[info] pipeline.start  models=text=off vision=disabled
[warn] pipeline.rung   strategy=blind  → no_text_model
[warn] pipeline.rung   strategy=hybrid → no_text_model
[warn] pipeline.rung   strategy=vision → vision_disabled
```

**After**:
```
✅ Using externally configured models: text=minimax-m2.5:cloud | vision=
   text  : minimax-m2.5:cloud   ← http://…
   vision: …
…
[info] pipeline.start  models=text=minimax-m2.5:cloud vision=…
[info] pipeline.rung   strategy=blind  → executes
```

(The misleading "No AI providers found — booting in tools-only mode" line is gone, because CLI flags pre-empt the auto-detect.)

## Tests

`src/__tests__/load-pipeline-config-overlay.test.ts` — 5 new tests covering:

- CLI flags synthesize a usable `PipelineConfig` when no disk config exists (the BUG-A scenario).
- CLI `--text-model + --base-url + --api-key` without `--provider` still propagate.
- `loadPipelineConfig()` with no overlay AND no disk file returns null (back-compat).
- Overlay with no CLI-sourced fields and no disk file returns null (no false positives).
- Vision flags (`--vision-model`) enable `layer3` when paired with a base URL.

Full suite: **817 passing, 1 skipped, 0 failing** (`npx vitest run`).

## Scope

Only the config-plumbing path is touched. No changes to tools, pipeline rungs, schema, or compactGroup.
