### PR TITLE
feat(mcp): --compact flag exposes the 6-compound surface over HTTP

### DIFF
--- a/src/surface/cli.ts
+++ b/src/surface/cli.ts
@@ -194,6 +194,7 @@ interface AgentModeOpts {
   noVision?: boolean;
   noLlm?: boolean;
   skipConsent?: boolean;
+  compact?: boolean;
 }
 
 async function runAgentMode(opts: AgentModeOpts): Promise<void> {
@@ -425,9 +426,16 @@ async function runAgentMode(opts: AgentModeOpts): Promise<void> {
   }
 
   // Mount /mcp behind the same Bearer-auth gate the legacy REST routes used.
+  // Compact-over-HTTP: default granular for backward compatibility (the
+  // dashboard at / calls 9 granular tool names — see dashboard.ts). External
+  // agent hosts can opt into the 6-compound public surface via
+  // `clawdcursor agent --compact` or `CLAWD_MCP_COMPACT=1`.
+  const compactSurface = opts.compact === true || process.env.CLAWD_MCP_COMPACT === '1';
+  let mcpToolCount = 0;
   try {
     const { createMcpServer, startMcpHttp } = await import('./mcp-server');
-    const { server: mcpServer } = await createMcpServer({ ctx: toolCtx });
+    const { server: mcpServer, toolCount } = await createMcpServer({ compact: compactSurface, ctx: toolCtx });
+    mcpToolCount = toolCount;
     app.use('/mcp', requireAuth);
     await startMcpHttp(mcpServer, app, '/mcp');
   } catch (err) {
@@ -445,8 +453,11 @@ async function runAgentMode(opts: AgentModeOpts): Promise<void> {
     console.log(`  GET  /health   — Readiness probe (no auth)`);
     console.log(`  POST /stop     — Graceful shutdown (auth, localhost only)`);
     console.log(`\nMCP endpoint (the only protocol):`);
-    console.log(`  POST /mcp      — JSON-RPC tools/call & tools/list (auth)`);
+    console.log(`  POST /mcp      — JSON-RPC tools/call & tools/list (auth) — ${compactSurface ? 'compact' : 'granular'} surface, ${mcpToolCount} tools`);
     console.log(`  GET  /mcp      — SSE notifications (auth)`);
+    if (!compactSurface) {
+      console.log(pc.gray(`   (tip: pass --compact or set CLAWD_MCP_COMPACT=1 to expose the 6-compound public surface)`));
+    }
     console.log(`\nAll mutating endpoints require: ${pc.cyan('Authorization: Bearer <token>')}`);
 
     if (llmAvailable) {
@@ -563,6 +574,7 @@ program
   .option('--no-vision', 'Refuse vision fallback — blind-first only (high-security mode)')
   .option('--no-llm', 'Force tools-only HTTP MCP mode; skip AI setup, scheduler, and credential validation')
   .option('--skip-consent', 'Skip consent prompt (requires NODE_ENV=development)')
+  .option('--compact', 'Expose the 6-compound MCP surface (computer/accessibility/window/system/browser/task) over HTTP /mcp instead of the 97 granular tools (also CLAWD_MCP_COMPACT=1)')
   .action(async (opts) => {
     await runAgentMode(opts);
   });
@@ -581,6 +593,7 @@ program
   .option('--accept', 'Accept desktop control consent non-interactively and start')
   .option('--no-vision', 'Refuse vision fallback — blind-first only (high-security mode)')
   .option('--no-llm', 'Force tools-only HTTP MCP mode; skip AI setup, scheduler, and credential validation')
+  .option('--compact', 'Expose the 6-compound MCP surface over HTTP /mcp (also CLAWD_MCP_COMPACT=1)')
   .action(async (opts) => {
     // v0.9 PR7.4 — `start` is now a thin deprecation alias for `agent`.
     // The legacy /task /favorites /execute REST surface was deleted; callers


### PR DESCRIPTION
## Why

`clawdcursor mcp --compact` (stdio) honored the compact flag and exposed the 6-compound MCP surface, but `clawdcursor agent` (HTTP-MCP) was hard-coded to `getAllTools()` and **always** served the 97 granular tools regardless of any flag.

This silently withheld the public surface the README and SKILL.md both advertise. A live test with an external agent (Sonnet driving clawdcursor through HTTP-MCP) confirmed the problem: the agent picked screenshot-first over a11y-first because the compact tools weren't on the menu.

Root cause: `src/surface/cli.ts:419` — `createMcpServer({ ctx: toolCtx })` with no `compact` argument.

## What

Thread the same `compact` flag through `runAgentMode`:

- `clawdcursor agent --compact` → 6 compound tools (`computer`, `accessibility`, `window`, `system`, `browser`, `task`) over `/mcp`
- `CLAWD_MCP_COMPACT=1 clawdcursor agent` → same, for non-CLI launchers (Docker, systemd unit files)
- Default: granular (97 tools). **This is intentional** — the dashboard at `/` calls 9 granular tool names (`scheduled_task_*`, `agent_status`, `submit_task`, `favorites_*`, `logs_recent`) and flipping the default would break it. The follow-up that audits the dashboard to ride on the compound surface is a separate PR.

Boot banner now logs the active surface so operators can see which catalog clients will receive:

```
MCP endpoint (the only protocol):
  POST /mcp      — JSON-RPC tools/call & tools/list (auth) — granular surface, 97 tools
  GET  /mcp      — SSE notifications (auth)
   (tip: pass --compact or set CLAWD_MCP_COMPACT=1 to expose the 6-compound public surface)
```

## Verification

- `npm test`: 834 / 836 pass on this branch (1 pre-existing flake at `tools-compact-transform.test.ts:239` that requires no daemon listening on `:3847` — env-dependent, **same failure on clean `origin/main`**, unrelated to this change)
- `npm run typecheck`: clean
- `--help` smoke: `clawdcursor agent --help` now lists the `--compact` flag
- `createMcpServer({ compact: true })` already has unit coverage at `src/__tests__/mcp-server.test.ts:57` asserting 6 tools

## Follow-ups (not in this PR)

- Migrate the 9 dashboard tools into the compound `system` surface so the default can flip to compact
- Add cost-class description prefixes (`[act]` / `[inspect]` / `[perceive-text]` / `[perceive-image]`) to the 6 compound tools and the 10 high-traffic granular fall-throughs — Phase A's shipping increment
- Add `list_guides()` to the compound `system` surface for guide discoverability
- Auto-CDP-DOM fallback in `find_element` / `read_screen` when the focused window is a browser