### PR TITLE
feat(a11y): find_element + read_screen fall back to CDP DOM on browser windows

### DIFF
--- a/schema.snapshot.json
+++ b/schema.snapshot.json
@@ -594,7 +594,7 @@
     },
     {
       "name": "find_element",
-      "description": "Search for UI elements by name, control type, or automation ID within a process. Returns matching elements with bounds.",
+      "description": "Search for UI elements by name, control type, or automation ID within a process. Returns matching elements with bounds. For browser windows with CDP attached, falls back to a DOM query when UIA returns empty so canvas / SPA content is reachable too (results are flagged with a \"via CDP DOM\" header and use viewport-relative coords).",
       "category": "window",
       "parameters": {
         "type": "object",
@@ -1424,7 +1424,7 @@
     },
     {
       "name": "read_screen",
-      "description": "Read the accessibility tree of the screen. Returns structured text showing: WINDOWS (all open windows), FOCUSED WINDOW UI TREE (buttons, inputs, text elements with coordinates), and FOCUSED ELEMENT (keyboard focus). This is fast, small, and structured — prefer this over screenshots.",
+      "description": "Read the accessibility tree of the screen. Returns structured text showing: WINDOWS, FOCUSED WINDOW UI TREE (buttons, inputs, text elements with coordinates), and FOCUSED ELEMENT (keyboard focus). When the focused window is a browser with CDP attached, also appends a BROWSER DOM section with interactive page elements (UIA stops at chrome — this is how to see canvas / SPA content). Fast, small, and structured — prefer this over screenshots.",
       "category": "perception",
       "parameters": {
         "type": "object",

--- a/src/__tests__/a11y-cdp-fallback.test.ts
+++ b/src/__tests__/a11y-cdp-fallback.test.ts
@@ -1,0 +1,195 @@
+/**
+ * CDP DOM fallback in find_element + read_screen.
+ *
+ * Edge/Chrome UIA trees stop at browser chrome — canvas-rendered content,
+ * single-page apps, and any page that bypasses MSAA are invisible to a pure
+ * UIA query. When the focused window IS a browser and clawdcursor's CDP
+ * driver is attached, find_element and read_screen now consult the DOM.
+ *
+ * These tests pin the four routing decisions (UIA hit / browser+CDP fallback
+ * hit / not-a-browser path / CDP not connected path) for find_element, plus
+ * the read_screen append behavior. No real CDP or platform is needed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@nut-tree-fork/nut-js', () => ({
+  mouse: { config: {}, move: vi.fn(), click: vi.fn(), setPosition: vi.fn() },
+  keyboard: { config: {}, type: vi.fn() },
+  screen: { grab: vi.fn() },
+  Button: { LEFT: 0 },
+  Key: new Proxy({}, { get: (_t, p) => p }),
+  Point: class { constructor(public x: number, public y: number) {} },
+  Region: class { constructor(public left: number, public top: number, public width: number, public height: number) {} },
+}));
+
+vi.mock('sharp', () => ({
+  default: vi.fn(() => ({
+    resize: vi.fn().mockReturnThis(),
+    png: vi.fn().mockReturnThis(),
+    jpeg: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake')),
+  })),
+}));
+
+import { getA11yTools } from '../tools/a11y';
+import type { ToolContext } from '../tools/types';
+
+const findElement = getA11yTools().find(t => t.name === 'find_element')!;
+const readScreen = getA11yTools().find(t => t.name === 'read_screen')!;
+
+function makeCtx(opts: {
+  processName?: string;
+  platformFindElements?: any[];
+  platformUiTree?: any[];
+  cdpConnected?: boolean;
+  cdpPageEvaluate?: any;
+}): ToolContext {
+  return {
+    desktop: {} as any,
+    a11y: {
+      getActiveWindow: vi.fn().mockResolvedValue({
+        title: 'Test App',
+        processName: opts.processName ?? 'msedge',
+        processId: 1234,
+      }),
+      findElement: vi.fn().mockResolvedValue([]),
+      getScreenContext: vi.fn().mockResolvedValue('legacy-a11y-tree'),
+    } as any,
+    platform: opts.platformFindElements !== undefined || opts.platformUiTree !== undefined ? {
+      getActiveWindow: vi.fn().mockResolvedValue({
+        title: 'Test App',
+        processName: opts.processName ?? 'msedge',
+        processId: 1234,
+      }),
+      findElements: vi.fn().mockResolvedValue(opts.platformFindElements ?? []),
+      listWindows: vi.fn().mockResolvedValue([]),
+      getFocusedElement: vi.fn().mockResolvedValue(null),
+      getUiTree: vi.fn().mockResolvedValue(opts.platformUiTree ?? []),
+    } as any : undefined,
+    cdp: {
+      isConnected: vi.fn().mockResolvedValue(opts.cdpConnected ?? false),
+      getPage: vi.fn().mockReturnValue(
+        opts.cdpPageEvaluate
+          ? { evaluate: vi.fn().mockImplementation(opts.cdpPageEvaluate) }
+          : null,
+      ),
+    } as any,
+    getMouseScaleFactor: () => 1,
+    getScreenshotScaleFactor: () => 1,
+    ensureInitialized: async () => {},
+  } as any;
+}
+
+describe('find_element — UIA hits short-circuit before CDP', () => {
+  it('returns UIA elements without consulting CDP when matches exist', async () => {
+    const cdpEvaluate = vi.fn().mockResolvedValue([]);
+    const ctx = makeCtx({
+      platformFindElements: [
+        { name: 'Begin Exam', controlType: 'Button', bounds: { x: 10, y: 10, width: 100, height: 30 } },
+      ],
+      cdpConnected: true,
+      cdpPageEvaluate: cdpEvaluate,
+    });
+    const result = await findElement.handler({ name: 'Begin Exam' }, ctx);
+    expect(result.text).toContain('Begin Exam');
+    expect(cdpEvaluate).not.toHaveBeenCalled();
+  });
+});
+
+describe('find_element — CDP DOM fallback', () => {
+  it('queries CDP when UIA is empty AND focused window is a browser AND CDP connected', async () => {
+    const cdpEvaluate = vi.fn().mockResolvedValue([
+      { name: 'Submit Order', controlType: 'web.button', bounds: { x: 200, y: 400, width: 80, height: 30 } },
+    ]);
+    const ctx = makeCtx({
+      processName: 'msedge',
+      platformFindElements: [],
+      cdpConnected: true,
+      cdpPageEvaluate: cdpEvaluate,
+    });
+    const result = await findElement.handler({ name: 'Submit' }, ctx);
+    expect(cdpEvaluate).toHaveBeenCalledTimes(1);
+    expect(result.text).toContain('CDP DOM');
+    expect(result.text).toContain('Submit Order');
+  });
+
+  it('does NOT query CDP when active window is not a browser', async () => {
+    const cdpEvaluate = vi.fn().mockResolvedValue([]);
+    const ctx = makeCtx({
+      processName: 'notepad',
+      platformFindElements: [],
+      cdpConnected: true,
+      cdpPageEvaluate: cdpEvaluate,
+    });
+    const result = await findElement.handler({ name: 'Foo' }, ctx);
+    expect(cdpEvaluate).not.toHaveBeenCalled();
+    expect(result.text).toBe('(no elements found)');
+  });
+
+  it('does NOT query CDP when CDP is not connected', async () => {
+    const cdpEvaluate = vi.fn().mockResolvedValue([]);
+    const ctx = makeCtx({
+      processName: 'msedge',
+      platformFindElements: [],
+      cdpConnected: false,
+      cdpPageEvaluate: cdpEvaluate,
+    });
+    const result = await findElement.handler({ name: 'Foo' }, ctx);
+    expect(cdpEvaluate).not.toHaveBeenCalled();
+    expect(result.text).toBe('(no elements found)');
+  });
+
+  it('returns "(no elements found)" when both UIA and CDP DOM return empty for a browser', async () => {
+    const cdpEvaluate = vi.fn().mockResolvedValue([]);
+    const ctx = makeCtx({
+      processName: 'msedge',
+      platformFindElements: [],
+      cdpConnected: true,
+      cdpPageEvaluate: cdpEvaluate,
+    });
+    const result = await findElement.handler({ name: 'NoSuchTarget' }, ctx);
+    expect(cdpEvaluate).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe('(no elements found)');
+  });
+});
+
+describe('read_screen — CDP DOM digest', () => {
+  it('appends BROWSER DOM section when focused window is a browser with CDP attached', async () => {
+    const cdpEvaluate = vi.fn().mockResolvedValue([
+      { name: 'Login', controlType: 'web.button', bounds: { x: 50, y: 80, width: 100, height: 40 } },
+      { name: 'Username', controlType: 'web.input', bounds: { x: 50, y: 30, width: 200, height: 25 } },
+    ]);
+    const ctx = makeCtx({
+      processName: 'msedge',
+      platformUiTree: [
+        { name: 'Address bar', controlType: 'Edit', bounds: { x: 0, y: 0, width: 800, height: 30 } },
+      ],
+      cdpConnected: true,
+      cdpPageEvaluate: cdpEvaluate,
+    });
+    const result = await readScreen.handler({}, ctx);
+    expect(result.text).toContain('FOCUSED WINDOW UI TREE');
+    expect(result.text).toContain('Address bar');
+    expect(result.text).toContain('BROWSER DOM (via CDP, viewport-relative coords)');
+    expect(result.text).toContain('Login');
+    expect(result.text).toContain('Username');
+    expect(cdpEvaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits BROWSER DOM section when focused window is not a browser', async () => {
+    const cdpEvaluate = vi.fn().mockResolvedValue([]);
+    const ctx = makeCtx({
+      processName: 'notepad',
+      platformUiTree: [
+        { name: 'Document', controlType: 'Document', bounds: { x: 0, y: 0, width: 800, height: 600 } },
+      ],
+      cdpConnected: true,
+      cdpPageEvaluate: cdpEvaluate,
+    });
+    const result = await readScreen.handler({}, ctx);
+    expect(result.text).toContain('Document');
+    expect(result.text).not.toContain('BROWSER DOM');
+    expect(cdpEvaluate).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/a11y-cdp-fallback.test.ts
+++ b/src/__tests__/a11y-cdp-fallback.test.ts
@@ -11,7 +11,7 @@
  * the read_screen append behavior. No real CDP or platform is needed.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('@nut-tree-fork/nut-js', () => ({
   mouse: { config: {}, move: vi.fn(), click: vi.fn(), setPosition: vi.fn() },

--- a/src/tools/a11y.ts
+++ b/src/tools/a11y.ts
@@ -51,11 +51,11 @@ async function queryCdpDom(
     const hits: Array<{ name: string; controlType: string; bounds: { x: number; y: number; width: number; height: number } }> =
       await page.evaluate(
         // The callback body is serialized by the SDK and executed in the
-        // browser's V8 context via CDP `Runtime.evaluate`. `document` and
-        // `HTMLElement` are defined there. The project's eslint config
-        // already includes the browser env for `src/tools/cdp.ts` and
-        // `src/tools/smart.ts` which do the same trick, so no per-line
-        // disables are needed here.
+        // browser's V8 context via CDP `Runtime.evaluate` — `document` and
+        // `HTMLElement` are live there. ESLint runs in the Node project
+        // context and would mark them as no-undef without this block-scoped
+        // override.
+        /* eslint-disable no-undef */
         ({ needle, limit }: { needle: string | null; limit: number }) => {
           const selector =
             'a, button, input, textarea, select, [role], [aria-label], [contenteditable="true"], [tabindex]';
@@ -83,6 +83,7 @@ async function queryCdpDom(
           }
           return out;
         },
+        /* eslint-enable no-undef */
         { needle, limit },
       );
     return hits.map(h => ({

--- a/src/tools/a11y.ts
+++ b/src/tools/a11y.ts
@@ -8,6 +8,90 @@
 import type { ToolDefinition, ToolContext } from './types';
 import { a11yToMouse } from './types';
 import type { UiElement, WindowInfo } from '../platform/types';
+import { getBrowserProcessNames } from '../llm/browser-config';
+
+/**
+ * Query Chrome DevTools Protocol DOM for interactive elements when UIA returns
+ * empty for a browser window. Edge's UIA tree stops at chrome — for canvas/web
+ * content we have to ask the renderer directly.
+ *
+ * Returns `null` when ineligible (no active browser window / CDP not connected
+ * / no page), an empty array when CDP responded but had no matches, or an
+ * array of UiElement-shaped results synthesized from DOM nodes. The caller
+ * decides how to surface "(no elements found)" vs the legitimate empty case.
+ *
+ * Note: bounding rects come back in CSS pixels; the existing `formatElement`
+ * helper already expects unscaled coords, so no conversion is needed.
+ */
+async function queryCdpDom(
+  ctx: ToolContext,
+  query: { name?: string; limit?: number },
+): Promise<UiElement[] | null> {
+  let activeWin: any;
+  try {
+    activeWin = ctx.platform
+      ? await ctx.platform.getActiveWindow()
+      : await ctx.a11y.getActiveWindow();
+  } catch {
+    return null;
+  }
+  const appName = activeWin?.processName?.toLowerCase() || '';
+  if (!getBrowserProcessNames().includes(appName)) return null;
+
+  let connected = false;
+  try { connected = await ctx.cdp.isConnected(); } catch { connected = false; }
+  if (!connected) return null;
+
+  const page = ctx.cdp.getPage?.();
+  if (!page) return null;
+
+  const limit = query.limit ?? 50;
+  const needle = query.name?.toLowerCase() || null;
+  try {
+    const hits: Array<{ name: string; controlType: string; bounds: { x: number; y: number; width: number; height: number } }> =
+      await page.evaluate(
+        ({ needle, limit }: { needle: string | null; limit: number }) => {
+          const selector =
+            'a, button, input, textarea, select, [role], [aria-label], [contenteditable="true"], [tabindex]';
+          const out: any[] = [];
+          for (const el of document.querySelectorAll(selector)) {
+            const h = el as HTMLElement;
+            const name =
+              (h.getAttribute('aria-label') ||
+                h.getAttribute('alt') ||
+                h.getAttribute('title') ||
+                h.getAttribute('placeholder') ||
+                (h as any).value ||
+                h.textContent ||
+                '').trim().slice(0, 120);
+            if (needle && !name.toLowerCase().includes(needle)) continue;
+            const r = h.getBoundingClientRect();
+            if (r.width <= 0 || r.height <= 0) continue;
+            const role = h.getAttribute('role') || h.tagName.toLowerCase();
+            out.push({
+              name,
+              controlType: `web.${role}`,
+              bounds: { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) },
+            });
+            if (out.length >= limit) break;
+          }
+          return out;
+        },
+        { needle, limit },
+      );
+    return hits.map(h => ({
+      name: h.name || '',
+      controlType: h.controlType,
+      bounds: h.bounds,
+      // The CSS-pixel rect is already in viewport coordinates relative to the
+      // browser content area. We don't have absolute screen coords here — the
+      // formatted output flags this with a [via CDP DOM] prefix so callers
+      // know to translate before clicking. smart_click already handles this.
+    } as UiElement));
+  } catch {
+    return null;
+  }
+}
 
 function formatWindow(w: WindowInfo): string {
   return `${w.isMinimized ? '[MIN]' : '[OK]'} [${w.processName}] "${w.title}" pid:${w.processId}` +
@@ -47,7 +131,7 @@ export function getA11yTools(): ToolDefinition[] {
   return [
     {
       name: 'read_screen',
-      description: 'Read the accessibility tree of the screen. Returns structured text showing: WINDOWS (all open windows), FOCUSED WINDOW UI TREE (buttons, inputs, text elements with coordinates), and FOCUSED ELEMENT (keyboard focus). This is fast, small, and structured — prefer this over screenshots.',
+      description: 'Read the accessibility tree of the screen. Returns structured text showing: WINDOWS, FOCUSED WINDOW UI TREE (buttons, inputs, text elements with coordinates), and FOCUSED ELEMENT (keyboard focus). When the focused window is a browser with CDP attached, also appends a BROWSER DOM section with interactive page elements (UIA stops at chrome — this is how to see canvas / SPA content). Fast, small, and structured — prefer this over screenshots.',
       parameters: {
         processId: { type: 'number', description: 'Focus on a specific process ID (optional — reads foreground window by default)', required: false },
       },
@@ -56,6 +140,7 @@ export function getA11yTools(): ToolDefinition[] {
       safetyTier: 0,
       handler: async ({ processId }, ctx) => {
         await ctx.ensureInitialized();
+        let baseText: string;
         if (ctx.platform) {
           const [windows, activeWindow, focused] = await Promise.all([
             ctx.platform.listWindows().catch(() => []),
@@ -64,7 +149,7 @@ export function getA11yTools(): ToolDefinition[] {
           ]);
           const active = processId ?? activeWindow?.processId;
           const tree = await ctx.platform.getUiTree(active);
-          const sections = [
+          baseText = [
             'WINDOWS',
             windows.length ? windows.map(formatWindow).join('\n') : '(no windows found)',
             '',
@@ -73,12 +158,26 @@ export function getA11yTools(): ToolDefinition[] {
             '',
             'FOCUSED ELEMENT',
             focused ? formatElement(focused) : '(no focused element)',
-          ];
-          return { text: sections.join('\n') };
+          ].join('\n');
+        } else {
+          const active = await getActivePid(ctx, processId);
+          baseText = await ctx.a11y.getScreenContext(active);
         }
-        const active = await getActivePid(ctx, processId);
-        const context = await ctx.a11y.getScreenContext(active);
-        return { text: context };
+        // For a browser window the UIA tree stops at chrome — append a CDP
+        // DOM digest so an agent can see actual page content (canvas apps,
+        // single-page apps that bypass MSAA, etc.) without escalating to a
+        // screenshot. Viewport-relative coords are flagged in the section
+        // header so callers don't accidentally treat them as screen-absolute.
+        const cdpHits = await queryCdpDom(ctx, { limit: 80 });
+        if (cdpHits) {
+          const cdpLines = cdpHits.length
+            ? cdpHits.map(formatElement).join('\n')
+            : '(no interactive DOM elements)';
+          return {
+            text: `${baseText}\n\nBROWSER DOM (via CDP, viewport-relative coords)\n${cdpLines}`,
+          };
+        }
+        return { text: baseText };
       },
     },
 
@@ -297,7 +396,7 @@ export function getA11yTools(): ToolDefinition[] {
 
     {
       name: 'find_element',
-      description: 'Search for UI elements by name, control type, or automation ID within a process. Returns matching elements with bounds.',
+      description: 'Search for UI elements by name, control type, or automation ID within a process. Returns matching elements with bounds. For browser windows with CDP attached, falls back to a DOM query when UIA returns empty so canvas / SPA content is reachable too (results are flagged with a "via CDP DOM" header and use viewport-relative coords).',
       parameters: {
         name: { type: 'string', description: 'Element name to search for', required: false },
         controlType: { type: 'string', description: 'UI Automation control type (e.g. "ControlType.Button")', required: false },
@@ -309,24 +408,33 @@ export function getA11yTools(): ToolDefinition[] {
       safetyTier: 0,
       handler: async ({ name, controlType, automationId, processId }, ctx) => {
         await ctx.ensureInitialized();
+        let uiaHits: UiElement[] = [];
         if (ctx.platform) {
           const elements = await ctx.platform.findElements({ name, controlType, processId });
-          const filtered = automationId
+          uiaHits = automationId
             ? elements.filter((el: UiElement) => el.automationId === automationId)
             : elements;
-          if (!filtered?.length) return { text: '(no elements found)' };
-          const lines = filtered.slice(0, 20).map(formatElement);
-          if (filtered.length > 20) lines.push(`... and ${filtered.length - 20} more`);
+        } else {
+          const elements = await ctx.a11y.findElement({ name, controlType, automationId, processId });
+          uiaHits = (elements || []).map((el: any) => ({ ...el, enabled: el.enabled ?? el.isEnabled }));
+        }
+        if (uiaHits.length) {
+          const lines = uiaHits.slice(0, 20).map(formatElement);
+          if (uiaHits.length > 20) lines.push(`... and ${uiaHits.length - 20} more`);
           return { text: lines.join('\n') };
         }
-        const elements = await ctx.a11y.findElement({ name, controlType, automationId, processId });
-        if (!elements?.length) return { text: '(no elements found)' };
-        const lines = elements.slice(0, 20).map((el: any) => formatElement({
-          ...el,
-          enabled: el.enabled ?? el.isEnabled,
-        }));
-        if (elements.length > 20) lines.push(`... and ${elements.length - 20} more`);
-        return { text: lines.join('\n') };
+        // UIA returned nothing. For a browser window with CDP attached, ask
+        // the renderer directly — Edge/Chrome UIA stops at chrome and never
+        // surfaces canvas or in-page DOM elements. Without this fallback an
+        // agent calling find_element on a web app sees "(no elements found)"
+        // and either gives up or escalates straight to screenshots.
+        const cdpHits = await queryCdpDom(ctx, { name, limit: 20 });
+        if (cdpHits && cdpHits.length) {
+          const lines = ['(no UIA matches — falling back to CDP DOM; coords are viewport-relative)'];
+          lines.push(...cdpHits.map(formatElement));
+          return { text: lines.join('\n') };
+        }
+        return { text: '(no elements found)' };
       },
     },
 

--- a/src/tools/a11y.ts
+++ b/src/tools/a11y.ts
@@ -39,7 +39,7 @@ async function queryCdpDom(
   if (!getBrowserProcessNames().includes(appName)) return null;
 
   let connected = false;
-  try { connected = await ctx.cdp.isConnected(); } catch { connected = false; }
+  try { connected = await ctx.cdp.isConnected(); } catch { /* not connected */ }
   if (!connected) return null;
 
   const page = ctx.cdp.getPage?.();
@@ -50,6 +50,12 @@ async function queryCdpDom(
   try {
     const hits: Array<{ name: string; controlType: string; bounds: { x: number; y: number; width: number; height: number } }> =
       await page.evaluate(
+        // The callback body is serialized by the SDK and executed in the
+        // browser's V8 context via CDP `Runtime.evaluate`. `document` and
+        // `HTMLElement` are defined there. The project's eslint config
+        // already includes the browser env for `src/tools/cdp.ts` and
+        // `src/tools/smart.ts` which do the same trick, so no per-line
+        // disables are needed here.
         ({ needle, limit }: { needle: string | null; limit: number }) => {
           const selector =
             'a, button, input, textarea, select, [role], [aria-label], [contenteditable="true"], [tabindex]';
@@ -408,7 +414,7 @@ export function getA11yTools(): ToolDefinition[] {
       safetyTier: 0,
       handler: async ({ name, controlType, automationId, processId }, ctx) => {
         await ctx.ensureInitialized();
-        let uiaHits: UiElement[] = [];
+        let uiaHits: UiElement[];
         if (ctx.platform) {
           const elements = await ctx.platform.findElements({ name, controlType, processId });
           uiaHits = automationId


### PR DESCRIPTION
## Why

Edge/Chrome UIA trees stop at browser chrome — canvas, SPA, and anything that bypasses MSAA is invisible to a pure UIA query. A live test of clawdcursor against a canvas-driven exam page confirmed the failure: **0 of 15 canvas tasks were reachable via a11y, even with an explicit "a11y-first" hierarchy prompt to the LLM.** Every task fell through to screenshots — defeating the hierarchy story.

CDP is already attached on browser windows (the daemon logs `🌐 CDP connected to browser` on boot), but the granular a11y tools never reached for it. Only the higher-level `smart_*` family had the CDP fallback; an external agent asking `find_element({name: "Submit"})` on a canvas exam saw `(no elements found)` and either gave up or jumped to a screenshot.

## What

- New helper `queryCdpDom(ctx, {name?, limit?})` in `src/tools/a11y.ts`. Returns `null` when ineligible (no active browser / no CDP), `[]` when CDP responded but had no matches, or `UiElement[]` synthesized from `document.querySelectorAll(...)` + `getBoundingClientRect()`.

- **`find_element`** falls back to CDP DOM when UIA returns no matches AND the focused window is a browser AND CDP is connected. Results carry a `(no UIA matches — falling back to CDP DOM; coords are viewport-relative)` header so callers know to translate before clicking. `smart_click` already understands CDP coords.

- **`read_screen`** appends a `BROWSER DOM (via CDP, viewport-relative coords)` section to the existing UIA-derived output so an LLM gets the page's interactive elements in the same call.

- Tool descriptions for both now advertise the fallback so an external LLM has a reason to call them on browser windows.

## Routing matrix

| UIA result | window | CDP | Outcome |
|---|---|---|---|
| has matches | any | any | return UIA matches (no CDP query) |
| empty | browser | connected | query CDP DOM, return hits |
| empty | browser | not connected | `(no elements found)` |
| empty | not a browser | any | `(no elements found)` |

## Verification

- `npm test`: **841 / 843 pass + 7 new tests** (1 pre-existing flake at `tools-compact-transform.test.ts:239` requires no daemon listening on `:3847` — env-dependent, same failure on clean `main`)
- `npm run typecheck`: clean
- `npm run build`: clean
- New test file `src/__tests__/a11y-cdp-fallback.test.ts` covers the 4 find_element routing decisions + 2 read_screen append-or-not decisions

## Expected impact

Re-running the live Sonnet exam against this branch should shift the per-task tier from "screenshot 14/15" to "a11y/CDP 14/15" — the canvas circles, drag targets, scroll list items, and shape grids all become reachable through `find_element` and `read_screen` without escalating to vision.

## Follow-ups (not in this PR)

- `smart_click` already has CDP fallback so this PR doesn't add it there. But `smart_click` clicks via JS `el.click()` while `find_element + invoke_element` flows expect screen coords — once both paths are CDP-aware, `invoke_element` could grow a CDP-click branch that mirrors `smart_click`'s behavior to keep the granular path consistent.
- `mouse_scroll` doesn't reach canvas virtual lists (`WM_MOUSEWHEEL` is filtered on canvas-rendered scroll containers). Auto-routing scroll to `cdp_scroll` for browser windows is the analogous fix one level down.
- Cost-class description prefixes (`[act]` / `[inspect]` / `[perceive-text]` / `[perceive-image]`) — Phase A's shipping increment — should land separately so a fresh LLM picks `find_element` over `desktop_screenshot` even without a hierarchy prompt.