### PR TITLE
fix(installer): never destroy user state, surface real errors

### DIFF
--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -41,32 +41,73 @@ Write-Host ""
 $DISPLAY_VERSION = if ($VERSION -eq "main") { "latest (main)" } else { $VERSION }
 
 if (Test-Path "$INSTALL_DIR\.git") {
-    # Update existing install
+    # Update existing install -- only proceed if the working tree is clean.
+    # The previous "git checkout && pull || rm -rf" path silently destroyed
+    # user state when git complained (dirty tree, diverged history, etc.).
     Write-Host "  Updating to $DISPLAY_VERSION..." -ForegroundColor Cyan
     Push-Location $INSTALL_DIR
-    git fetch --all --tags --quiet 2>&1 | Out-Null
-    git checkout $VERSION --quiet 2>&1 | Out-Null
-    if ($LASTEXITCODE -eq 0) {
-        git pull --quiet 2>&1 | Out-Null
+
+    $dirty = git status --porcelain 2>$null
+    if ($dirty) {
         Pop-Location
-    } else {
-        Write-Host "  Update failed, doing fresh install..." -ForegroundColor Yellow
-        Pop-Location; Set-Location $HOME
-        Remove-Item -Recurse -Force $INSTALL_DIR 2>$null
-        git clone https://github.com/AmrDab/clawdcursor.git --branch $VERSION $INSTALL_DIR --quiet 2>&1 | Out-Null
+        Write-Host "  [X] Refusing to update: $INSTALL_DIR has uncommitted changes." -ForegroundColor Red
+        Write-Host ""
+        $dirtyLines = @($dirty -split "`r?`n" | Where-Object { $_ })
+        foreach ($line in ($dirtyLines | Select-Object -First 20)) { Write-Host "      $line" }
+        if ($dirtyLines.Count -gt 20) { Write-Host "      ... and $($dirtyLines.Count - 20) more" }
+        Write-Host ""
+        Write-Host "  Pick one and re-run the installer:" -ForegroundColor Yellow
+        Write-Host "    - Stash:    Push-Location $INSTALL_DIR; git stash; Pop-Location"
+        Write-Host "    - Discard:  Push-Location $INSTALL_DIR; git reset --hard; git clean -fd; Pop-Location"
+        Write-Host "    - Sidecar:  `$env:INSTALL_DIR='$HOME\clawdcursor-new'; irm https://clawdcursor.com/install.ps1 | iex"
+        exit 1
     }
-} else {
-    # Fresh install (remove corrupted dir if exists)
-    if (Test-Path $INSTALL_DIR) {
-        Set-Location $HOME
-        Remove-Item -Recurse -Force $INSTALL_DIR 2>$null
+
+    $fetchErr = (git fetch --all --tags --quiet 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        Pop-Location
+        Write-Host "  [X] Failed to fetch from GitHub (network or auth issue):" -ForegroundColor Red
+        foreach ($line in ($fetchErr -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
+        exit 1
     }
-    Write-Host "  Downloading $DISPLAY_VERSION..." -ForegroundColor Cyan
-    git clone https://github.com/AmrDab/clawdcursor.git --branch $VERSION $INSTALL_DIR --quiet 2>&1 | Out-Null
-}
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  [X] Download failed. Check your internet and try again." -ForegroundColor Red
+
+    $coErr = (git checkout $VERSION --quiet 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        Pop-Location
+        Write-Host "  [X] Failed to switch to '$VERSION':" -ForegroundColor Red
+        foreach ($line in ($coErr -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
+        Write-Host "      (tree is clean -- likely the ref doesn't exist on origin)"
+        exit 1
+    }
+
+    # Only pull if we landed on a branch; tag/SHA checkouts are detached.
+    git symbolic-ref -q HEAD 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        $pullErr = (git pull --ff-only --quiet 2>&1 | Out-String)
+        if ($LASTEXITCODE -ne 0) {
+            Pop-Location
+            Write-Host "  [X] Failed to fast-forward '$VERSION':" -ForegroundColor Red
+            foreach ($line in ($pullErr -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
+            Write-Host "      Local branch may have diverged from origin. Resolve manually."
+            exit 1
+        }
+    }
+    Pop-Location
+} elseif (Test-Path $INSTALL_DIR) {
+    # Directory exists but isn't a git checkout. Could be user data we
+    # don't recognise -- refuse rather than silently Remove-Item -Force.
+    Write-Host "  [X] $INSTALL_DIR exists but is not a git checkout." -ForegroundColor Red
+    Write-Host "      Move or remove it manually, then re-run. (We won't delete"
+    Write-Host "      it for you because it might contain unrelated files.)"
     exit 1
+} else {
+    Write-Host "  Downloading $DISPLAY_VERSION..." -ForegroundColor Cyan
+    $cloneErr = (git clone https://github.com/AmrDab/clawdcursor.git --branch $VERSION $INSTALL_DIR --quiet 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  [X] Clone failed:" -ForegroundColor Red
+        foreach ($line in ($cloneErr -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
+        exit 1
+    }
 }
 
 # ── 4. Install dependencies ──────────────────────────────────────────────────
@@ -91,7 +132,7 @@ Write-Host "  Linking..." -ForegroundColor Cyan
 $npmPrefix = (npm prefix -g 2>$null)
 if ($npmPrefix) {
     $npmPrefix = $npmPrefix.Trim()
-    # Remove old shims — prevents EEXIST errors on re-install
+    # Remove old shims -- prevents EEXIST errors on re-install
     foreach ($ext in @('', '.cmd', '.ps1')) {
         $shimPath = "$npmPrefix\clawdcursor$ext"
         if (Test-Path $shimPath) { Remove-Item -Force $shimPath 2>$null }
@@ -152,7 +193,7 @@ Write-Host ""
 Write-Host "    Autonomous agent" -NoNewline -ForegroundColor White
 Write-Host " (clawdcursor brings the AI brain):" -ForegroundColor Gray
 if ($configPresent) {
-    Write-Host "      Config already saved — skip step 1 unless you want to reconfigure." -ForegroundColor DarkGray
+    Write-Host "      Config already saved -- skip step 1 unless you want to reconfigure." -ForegroundColor DarkGray
     Write-Host "      1. clawdcursor doctor   " -NoNewline -ForegroundColor DarkYellow
     Write-Host "(optional) Re-check / change AI provider + models" -ForegroundColor Gray
 } else {
@@ -167,7 +208,7 @@ Write-Host " (your editor brings the AI brain):" -ForegroundColor Gray
 Write-Host "      Register " -NoNewline -ForegroundColor Gray
 Write-Host "clawdcursor mcp" -NoNewline -ForegroundColor Yellow
 Write-Host " with Claude Code, Cursor, Windsurf, Zed, etc." -ForegroundColor Gray
-Write-Host "      No daemon, no API key in clawdcursor — your editor handles both." -ForegroundColor Gray
+Write-Host "      No daemon, no API key in clawdcursor -- your editor handles both." -ForegroundColor Gray
 Write-Host ""
 Write-Host "  Run now:" -ForegroundColor White
 if (-not $consentGiven) {

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -40,25 +40,68 @@ echo ""
 DISPLAY_VERSION="$VERSION"
 [ "$VERSION" = "main" ] && DISPLAY_VERSION="latest (main)"
 
+ERR_LOG=$(mktemp -t clawd-installer.XXXXXX 2>/dev/null || echo "/tmp/clawd-installer-$$.log")
+trap 'rm -f "$ERR_LOG"' EXIT
+indent_err() { sed 's/^/      /' "$ERR_LOG"; }
+
 if [ -d "$INSTALL_DIR/.git" ]; then
-    # Update existing install
+    # Update existing install — only proceed if the working tree is clean.
+    # The previous "git checkout && pull || rm -rf" path silently destroyed
+    # user state when git complained (dirty tree, diverged history, etc.).
     echo "  📦 Updating to $DISPLAY_VERSION..."
     cd "$INSTALL_DIR"
-    git fetch --all --tags --quiet 2>/dev/null
-    git checkout "$VERSION" --quiet 2>/dev/null && git pull --quiet 2>/dev/null || {
-        echo "  ⚠️  Update failed, doing fresh install..."
-        cd "$HOME"
-        rm -rf "$INSTALL_DIR"
-        git clone https://github.com/AmrDab/clawdcursor.git --branch "$VERSION" "$INSTALL_DIR" --quiet
-    }
+
+    DIRTY=$(git status --porcelain 2>/dev/null)
+    if [ -n "$DIRTY" ]; then
+        echo "  ❌ Refusing to update: $INSTALL_DIR has uncommitted changes."
+        echo ""
+        echo "$DIRTY" | head -20 | sed 's/^/      /'
+        DIRTY_COUNT=$(echo "$DIRTY" | wc -l | tr -d ' ')
+        [ "$DIRTY_COUNT" -gt 20 ] && echo "      ... and $((DIRTY_COUNT - 20)) more"
+        echo ""
+        echo "  Pick one and re-run the installer:"
+        echo "    • Stash:      cd $INSTALL_DIR && git stash"
+        echo "    • Discard:    cd $INSTALL_DIR && git reset --hard && git clean -fd"
+        echo "    • Sidecar:    INSTALL_DIR=\$HOME/clawdcursor-new curl -fsSL https://clawdcursor.com/install.sh | bash"
+        exit 1
+    fi
+
+    if ! git fetch --all --tags --quiet 2>"$ERR_LOG"; then
+        echo "  ❌ Failed to fetch from GitHub (network or auth issue):"
+        indent_err
+        exit 1
+    fi
+
+    if ! git checkout "$VERSION" --quiet 2>"$ERR_LOG"; then
+        echo "  ❌ Failed to switch to '$VERSION':"
+        indent_err
+        echo "      (tree is clean — likely the ref doesn't exist on origin)"
+        exit 1
+    fi
+
+    # Only pull if we landed on a branch — tag/SHA checkouts are detached.
+    if git symbolic-ref -q HEAD >/dev/null 2>&1; then
+        if ! git pull --ff-only --quiet 2>"$ERR_LOG"; then
+            echo "  ❌ Failed to fast-forward '$VERSION':"
+            indent_err
+            echo "      Local branch may have diverged from origin. Resolve manually."
+            exit 1
+        fi
+    fi
 elif [ -d "$INSTALL_DIR" ]; then
-    # Corrupted — no .git, remove and reclone
-    rm -rf "$INSTALL_DIR"
-    echo "  📦 Downloading $DISPLAY_VERSION..."
-    git clone https://github.com/AmrDab/clawdcursor.git --branch "$VERSION" "$INSTALL_DIR" --quiet
+    # Directory exists but isn't a git checkout. Could be user data we
+    # don't recognise — refuse rather than silently rm -rf.
+    echo "  ❌ $INSTALL_DIR exists but is not a git checkout."
+    echo "      Move or remove it manually, then re-run. (We won't delete"
+    echo "      it for you because it might contain unrelated files.)"
+    exit 1
 else
     echo "  📦 Downloading $DISPLAY_VERSION..."
-    git clone https://github.com/AmrDab/clawdcursor.git --branch "$VERSION" "$INSTALL_DIR" --quiet
+    if ! git clone https://github.com/AmrDab/clawdcursor.git --branch "$VERSION" "$INSTALL_DIR" --quiet 2>"$ERR_LOG"; then
+        echo "  ❌ Clone failed:"
+        indent_err
+        exit 1
+    fi
 fi
 
 # ── 4. Install dependencies ──────────────────────────────────────────────────


### PR DESCRIPTION
## The bug, surfaced by a real user report

A user ran `irm https://clawdcursor.com/install.ps1 | iex` to update their existing install. Network was fine, GitHub was reachable. The installer printed:

```
  Updating to latest (main)...
  [X] Download failed. Check your internet and try again.
```

Actual cause: their `~/clawdcursor` working tree had uncommitted changes. `git pull` refused to clobber them, and the installer mapped every non-zero git exit to "Download failed".

That is bug #1 â€” a lying error message. **Bug #2 is worse**: in the alternate path (when `git checkout` itself failed), the installer ran `rm -rf $INSTALL_DIR` / `Remove-Item -Recurse -Force $INSTALL_DIR` and re-cloned. Any uncommitted feature work would be deleted with no consent and no recovery path.

## The fix

Both `docs/install.sh` and `docs/install.ps1` update paths rewritten for safety:

- **Refuse to clobber a dirty tree.** `git status --porcelain` runs first. If there are uncommitted changes, the installer prints the dirty file list (capped at 20) and exits with three concrete recovery paths: stash / discard / sidecar (`INSTALL_DIR=...`).
- **Per-step error surfacing.** `git fetch`, `git checkout`, and `git pull --ff-only` each capture their own stderr. On failure, indented git output prints with a one-line hint (network/auth, missing ref, diverged branch). No more catch-all "Download failed".
- **Pull only on a branch.** `git symbolic-ref -q HEAD` guards the pull, so tag/SHA checkouts no longer trigger spurious detached-HEAD pull failures.
- **Non-git `$INSTALL_DIR` => refuse.** If the dir exists without `.git`, no more silent `rm -rf`.

## install.ps1 PowerShell-5.1 footgun (also fixed)

The PowerShell parser rejected the file with "Missing closing `}`" until I removed em-dashes. Windows PowerShell 5.1 without a BOM decodes the file as ANSI; UTF-8 em-dashes (bytes E2 80 94) become three Windows-1252 chars including a literal `"` byte that breaks string state, silently corrupting parse for the rest of the file. Replaced em-dashes throughout `install.ps1` with `--`. `install.sh` keeps em-dashes (bash handles UTF-8 natively).

## Verification

- `bash -n docs/install.sh` clean
- PowerShell `Parser::ParseFile docs/install.ps1` 0 errors
- `npm run lint` 0 errors / `typecheck` clean / `schema` OK / `build` clean
- `npm run test:ci` 841/843 pass (1 pre-existing env-dependent flake â€” `tools-compact-transform.test.ts:239` requires `:3847` free)
- sync-version pin examples still match (`VERSION=v0.9.4`, `$env:VERSION='v0.9.4'`)

## Behavior matrix

| Pre-state | Old installer | New installer |
|-----------|---------------|---------------|
| Fresh, no dir | clone | clone (unchanged) |
| Dir exists, no `.git` | rm -rf then clone (DESTRUCTIVE) | refuse |
| Clean tree, ref exists | succeeds | succeeds |
| Dirty tree, any git failure | rm -rf then clone (DESTRUCTIVE) | refuse with file list + 3 recovery paths |
| Network error during fetch | "Download failed. Check your internet" | "Failed to fetch from GitHub: \<git output\>" |
| Ref doesn't exist on origin | "Download failed. Check your internet" | "Failed to switch to '\<VERSION\>': \<git output\>" |
| Diverged local branch | masked / re-cloned | "Failed to fast-forward: \<git output\>" |
