### PR TITLE
fix(agent): snapshot TaskResult onto state.lastResult so compact task can report success

### DIFF
--- a/src/__tests__/agent-last-result.test.ts
+++ b/src/__tests__/agent-last-result.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Agent.executeTask must snapshot its TaskResult onto state.lastResult
+ * before resolving, so external pollers (delegate_to_agent compact tool)
+ * can read the outcome via agent_status after observing status === 'idle'.
+ *
+ * Pre-fix bug: the agent only stored {status, currentTask, stepsCompleted,
+ * stepsTotal} on state and returned the TaskResult to the caller. The
+ * compact `task` action polls agent_status → reads data.lastResult →
+ * undefined → reports `{success: false}` even on real success.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@nut-tree-fork/nut-js', () => ({
+  mouse: { config: {}, move: vi.fn(), click: vi.fn(), setPosition: vi.fn() },
+  keyboard: { config: {}, type: vi.fn() },
+  screen: { grab: vi.fn() },
+  Button: { LEFT: 0 },
+  Key: new Proxy({}, { get: (_t, p) => p }),
+  Point: class { constructor(public x: number, public y: number) {} },
+  Region: class { constructor(public left: number, public top: number, public width: number, public height: number) {} },
+}));
+
+vi.mock('sharp', () => ({
+  default: vi.fn(() => ({
+    resize: vi.fn().mockReturnThis(),
+    png: vi.fn().mockReturnThis(),
+    jpeg: vi.fn().mockReturnThis(),
+    toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake')),
+  })),
+}));
+
+import { Agent } from '../core/agent';
+
+/**
+ * Build a minimal Agent stub with a pre-loaded pipelineUnified mock.
+ * Sidesteps the heavy NativeDesktop / AccessibilityBridge / OcrEngine
+ * construction by reusing Agent.prototype directly. Sufficient for testing
+ * the executeTask -> state.lastResult contract.
+ */
+function makeAgentWithPipeline(pipelineResult: {
+  success: boolean;
+  text?: string;
+  trace?: any[];
+  path?: string;
+}) {
+  const agent: any = Object.create(Agent.prototype);
+  agent.state = { status: 'idle', stepsCompleted: 0, stepsTotal: 0 };
+  agent.aborted = false;
+  agent.taskExecutionLocked = false;
+  agent.resolvedConfig = null;
+  agent.pipelineUnified = {
+    run: vi.fn(async () => ({
+      success: pipelineResult.success,
+      text: pipelineResult.text ?? '',
+      trace: pipelineResult.trace ?? [],
+      path: pipelineResult.path ?? 'unified',
+    })),
+  };
+  return agent as Agent;
+}
+
+describe('Agent.executeTask populates state.lastResult', () => {
+  it('sets state.lastResult on success so pollers can read it', async () => {
+    const agent: any = makeAgentWithPipeline({ success: true, text: 'task complete' });
+
+    const returnedResult = await agent.executeTask('open notepad');
+
+    const state = agent.getState();
+    expect(state.status).toBe('idle');
+    expect(state.lastResult).toBeDefined();
+    expect(state.lastResult.success).toBe(true);
+    // The lastResult on state must be the same shape that was returned
+    // to the direct caller — that's the whole point of the snapshot.
+    expect(state.lastResult).toEqual(returnedResult);
+  });
+
+  it('sets state.lastResult on failure (success=false)', async () => {
+    const agent: any = makeAgentWithPipeline({ success: false, text: 'task failed' });
+
+    await agent.executeTask('open something that does not exist');
+
+    const state = agent.getState();
+    expect(state.status).toBe('idle');
+    expect(state.lastResult).toBeDefined();
+    expect(state.lastResult.success).toBe(false);
+  });
+
+  it('exposes lastResult on a fresh getState() snapshot (not a reference)', async () => {
+    const agent: any = makeAgentWithPipeline({ success: true });
+    await agent.executeTask('task');
+
+    const snapA = agent.getState();
+    const snapB = agent.getState();
+    // getState returns a shallow copy; lastResult itself is shared by ref
+    // (that's fine — TaskResult is treated as immutable by readers).
+    expect(snapA).not.toBe(snapB);
+    expect(snapA.lastResult).toEqual(snapB.lastResult);
+  });
+
+  it('clears lastResult at start of next task (no stale read while in flight)', async () => {
+    const agent: any = makeAgentWithPipeline({ success: true });
+    await agent.executeTask('first task');
+    expect(agent.getState().lastResult).toBeDefined();
+
+    // Swap pipelineUnified.run to a deferred promise so we can observe
+    // state mid-task and confirm lastResult was cleared at the start.
+    let resolvePipeline: (v: any) => void = () => {};
+    const deferred = new Promise(r => { resolvePipeline = r; });
+    agent.pipelineUnified.run = vi.fn(() => deferred);
+
+    const secondTask = agent.executeTask('second task');
+    // Yield once so the state-clear at the top of _executeTaskUnified runs.
+    await new Promise(r => setImmediate(r));
+
+    expect(agent.getState().status).toBe('thinking');
+    expect(agent.getState().lastResult).toBeUndefined();
+
+    resolvePipeline({ success: true, text: '', trace: [], path: 'unified' });
+    await secondTask;
+    expect(agent.getState().lastResult).toBeDefined();
+  });
+});

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -206,7 +206,9 @@ export class Agent {
       // (task + correlationId + models) when pipeline.start fires.
     }
 
-    this.state = { ...this.state, status: 'thinking', currentTask: task, stepsCompleted: 0, stepsTotal: 0 };
+    // Clear lastResult at task start so a poller can't read a stale result
+    // from a prior run while a new task is in flight.
+    this.state = { ...this.state, status: 'thinking', currentTask: task, stepsCompleted: 0, stepsTotal: 0, lastResult: undefined };
 
     const result = await this.pipelineUnified.run({
       task,
@@ -238,12 +240,18 @@ export class Agent {
       console.log(`   ${result.text}`);
     }
 
-    this.state.status = 'idle';
-    return {
+    // Snapshot the result onto state BEFORE returning so external pollers
+    // (delegate_to_agent compact tool) can read the outcome via agent_status
+    // after seeing status === 'idle'. Without this snapshot the compact
+    // `task` action returned success:false even on successful completion
+    // because lastResult was undefined.
+    const taskResult: TaskResult = {
       success: result.success,
       steps,
       duration: Date.now() - startTime,
     };
+    this.state = { ...this.state, status: 'idle', lastResult: taskResult };
+    return taskResult;
   }
 
   abort(): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,14 @@ export interface AgentState {
   currentStep?: string;
   stepsCompleted: number;
   stepsTotal: number;
+  /**
+   * Result of the most recent `executeTask()` call. Populated when status
+   * transitions back to `idle`; cleared at the start of the next task. Lets
+   * external pollers (e.g. the `delegate_to_agent` compact tool) read the
+   * outcome of a completed task without holding a reference to the
+   * `executeTask` promise.
+   */
+  lastResult?: TaskResult;
 }
 
 export interface ClawdConfig {


### PR DESCRIPTION
## The bug

The compact `task` compound â€” one of the 6 headline tools the README pitches â€” routes through `delegate_to_agent` (in `src/tools/orchestration.ts:115`). After submitting via `submit_task`, that handler polls `agent_status` until `status === 'idle'` and then reads `data.lastResult` to report `{success, verified, steps, lastAction}` back to the calling LLM.

But `AgentState` (in `src/types.ts:80`) had no `lastResult` field. `getState()` only exposed `{status, currentTask, currentStep, stepsCompleted, stepsTotal}`. After `executeTask()` finished, the result was returned to the direct caller but never written onto state. The poll-then-read path saw `undefined` and reported `{success: false, steps: 0}` on every completed task â€” **including successful ones.**

This meant `accessibility.invoke({ action: "task", task: "..." })` (the compact form) always reported failure to its caller, even when the task succeeded. One of the six headline tools was silently broken in v0.9.4.

## The fix

Three small edits:

- **`src/types.ts:80`** â€” add `lastResult?: TaskResult` to `AgentState`.
- **`src/core/agent.ts:209`** â€” clear `lastResult: undefined` at task start so pollers can't read a stale prior result while a new task is in flight.
- **`src/core/agent.ts:241-246`** â€” snapshot the `TaskResult` onto `state.lastResult` immediately before resolving the `executeTask()` promise.

Total: +8/-3 LOC in source.

## Test coverage

`src/__tests__/agent-last-result.test.ts` (4 tests):

1. Success path sets `lastResult` that matches the returned `TaskResult`
2. Failure path (`success: false`) still populates `lastResult`
3. `getState()` returns a fresh snapshot each call (not a shared reference)
4. `lastResult` is cleared at the start of the next task â€” verified via a deferred-pipeline trick that observes state mid-task

## Out of scope (deferred)

- The `executeTask()` method has no `try/catch` around `pipelineUnified.run()`. If the pipeline throws, `state` is left in an inconsistent state and `lastResult` is never set. Separate fix.
- `abort()` resets state to clean `{idle}` â€” `lastResult` stays undefined for aborted tasks. That's correct (no completion occurred), so no change.

## Verification

- `npm run lint` 0 errors
- `npm run typecheck` clean
- `npm run typecheck:tests` clean
- `npm run test:mcp-schema-snapshot` OK
- `npm run build` clean
- `npm run test:ci` **846 / 847 pass + 1 skipped** (gain of +4 over main; the 1 skip is the known `mcp-orphan-teardown` Linux flake)

## Why this is v0.9.5-urgent

The compact surface (6 tools) is the README headline. If a fresh user installs from the npm publish we're about to do and the first compact action they try (`task`) silently reports failure, that's the worst possible first impression. Fix lands before npm publish or it doesn't go.
