### PR TITLE
docs: hygiene pass before next release (post-audit cleanups)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ debug/
 .clawd-config.json
 qa-tests/
 .claude/
+test-runs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Clawd Cursor will be documented in this file.
 
+## [Unreleased]
+
+### Docs — `Toolbox` / `Tools` naming + restored action-enum tables (PR #111)
+
+The repositioning in #93 inadvertently stripped the per-toolbox action
+enum tables that v0.9.3 shipped. Readers landing on the post-v0.9.4
+README saw vague descriptions like *"computer — Mouse, keyboard,
+screenshot. Raw I/O."* with no way to discover the ~70 verbs each
+compound tool actually exposes short of querying `tools/list`. The
+tables are restored verbatim from v0.9.3, and the two sections are
+labeled **`Toolbox` — 6 compound tools (recommended)** and **`Tools`
+— 97 granular primitives** to make the catalog choice unambiguous.
+
+
 ## [0.9.5] - 2026-05-21 — repositioning + compact `task` fix + macOS Tahoe silent screenshots + npm publish prep
 
 Three threads landed: a documentation reframe so the README finally
@@ -67,6 +81,22 @@ the existing CG path on macOS 12-13 where CG is still silent.
 npm `prepare` lifecycle runs on `npm pack` / `npm publish`, so the
 published tarball always reflects the current source rather than
 shipping a stale `dist/` from the developer's last `npm run build`.
+
+### Fixed — installer no longer destroys user state on dirty tree (PR #108, backfilled to v0.9.5)
+
+The `irm https://clawdcursor.com/install.ps1 | iex` and equivalent
+`curl … | bash` paths previously did a `git checkout && git pull` and,
+on any non-zero exit, ran `rm -rf $INSTALL_DIR` and re-cloned from
+scratch. Any uncommitted work in the user's tree — feature branches,
+dirty edits, untracked scratch files — was destroyed with no consent
+and no recovery path. The error message also lied about the cause: a
+dirty tree, a missing ref, or a diverged branch all surfaced as
+"Download failed. Check your internet and try again."
+
+Both installers now refuse to update a dirty tree, surface the real
+`git` stderr on failure, and never delete `$INSTALL_DIR` without
+explicit user action. `install.ps1` also dropped UTF-8 em-dashes in
+comments to fix a Windows-PowerShell-5.1 ANSI-decoding parser issue.
 
 ### Notes
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -498,6 +498,32 @@ Per-OS setup notes:
 
 ---
 
+**What's new in 0.9.5** - repositioning + compact `task` fix + macOS Tahoe silent screenshots:
+
+- **README + homepage reframed.** Tagline is now *"The local MCP server that gives any agent safe desktop control."* The 6 compound tools are presented under the "Toolbox" label (each toolbox carries an `action` enum of ~10-15 verbs); the 97 underlying primitives are presented under "Tools." Public surface unchanged — just clearer naming. (#93, #111)
+- **Compact `task` compound now returns `success: true` on success** instead of always `success: false`. `AgentState` gained a `lastResult?: TaskResult` field that `executeTask()` snapshots before resolving, so the `delegate_to_agent` poll-then-read path actually sees the outcome. One of the 6 headline tools was silently broken in v0.9.4. (#110)
+- **Silent screenshots on macOS 14+ via ScreenCaptureKit.** macOS 26 Tahoe added a "screen captured" white-flash animation that fires on every `CGWindowListCreateImage` call. New SCK capture path on macOS 14+ bypasses the flash hook. Falls back to the existing CG path on macOS 12-13 where CG is still silent. (#109)
+- **`npm publish` prep.** `prepare: tsc && node dist/postbuild.js` added to `package.json` so the npm `prepare` lifecycle (run on `npm pack` / `npm publish`) always rebuilds `dist/` from current source. Groundwork for shipping the package to npm.
+
+**What's new in 0.9.4** - external-agent reliability + browser DOM reachability:
+
+- **`clawdcursor agent --compact` exposes the 6-compound MCP surface over HTTP.** Previously stdio-only (`clawdcursor mcp --compact`); the HTTP daemon was hard-coded to all 97 granular tools, silently breaking the "6 compact tools" pitch for external agents connecting over HTTP. Also reachable via `CLAWD_MCP_COMPACT=1` for non-CLI launchers. Default stays granular because the daemon dashboard at `/` still calls 9 granular tool names. (#106)
+- **CDP DOM fallback in `find_element` + `read_screen`.** When the focused window is a recognized browser and clawdcursor's CDP driver is connected, these tools now also query `document.querySelectorAll('a, button, input, ..., [aria-label], [role]')` and fold matches into the response. `find_element` flags CDP results with `(via CDP DOM; coords are viewport-relative)`; `read_screen` appends a `BROWSER DOM` section side-by-side with the UIA tree. (#107)
+- **Pipeline ladder climbs past rung LLM errors.** Replaced the stringly-typed "aborted" branch with a `RungFailureCategory` tagged-union + single-source-of-truth mapper. Chain-abort gate hard-aborts only on `user_abort` / `infra_error` / `anti_pattern` / high-confidence `verifier_rejected`. (#104)
+- **Blind-mode coordinate-click guardrail.** Refuses raw `click(x, y)` calls when `mode === 'blind'` AND no a11y-aware selector succeeded in the prior 2 turns. Stops coordinate hallucination on canvas content. (#103)
+- **CLI `--text-model` / `--api-key` / `--base-url` reach runtime.** `loadPipelineConfig` now accepts a `ResolvedConfig` overlay; CLI-tagged fields override disk values. (#105)
+- **`smart_click` candidates + macOS multi-window + `open_url` tier + a11y description fallback.** Several issue-101 fixes bundled. (#102)
+- **Installer no longer destroys user state on dirty tree.** `irm | iex` and `curl | bash` flows now refuse to update when the working tree has uncommitted changes; surface real git errors instead of the catch-all "Download failed". (#108)
+
+**What's new in 0.9.3** - tool-layer fixes + live-test report:
+
+- **Linux SIGSEGV on MCP stdin teardown fixed.** `releaseMcp` no longer calls `process.exit()` synchronously inside a stdin `'end'` handler.
+- **`navigate_browser` PowerShell shell injection (Win32 branch) fixed.** Direct `execFile()` against `msedge.exe`; no more shell-quoting escape vectors.
+- **`screenshot_full` MIME-type lie fixed.** Was hardcoded `image/png` but `captureForLLM()` returns JPEG by default. Now follows actual `frame.format`.
+- **`learn_app` silent no-op fixed.** Returned `{saved: true}` even when nothing was persisted; now returns `{saved: false, reason, isError: true}` for no-payload cases.
+- **Windows window-title UTF-8 corruption fixed.** `scripts/ps-bridge.ps1` and `ocr-recognize.ps1` now force UTF-8 on stdin/stdout.
+- **Compact `direction` enum dropped `scroll_horizontal` values.** Restored.
+
 **What's new in 0.9.2** - reliability + scanner-friendliness:
 
 - **MCP reconnect no longer wedged by stale lockfiles or orphan processes.** `~/.clawdcursor/{start,mcp,serve}.pid` is now JSON `{v, pid, startTime, mode}` verified by OS-reported start-time match — Windows PID recycling no longer fools `claimPidFile` into thinking a long-dead clawdcursor is still live. The `mcp` command also exits cleanly on stdin EOF, so an editor host that crashes without reaping its child no longer leaves an orphan holding the lock. `clawdcursor stop` and `clawdcursor uninstall` both handle the new format and the legacy bare-int format transparently.

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <!--
-    AGENT-READABLE SUMMARY (v0.9.4)
+    AGENT-READABLE SUMMARY (v0.9.5)
     clawdcursor: the local MCP server that gives any agent safe desktop control.
 
     ── WHAT IT IS ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Bundles four small fixes surfaced by the pre-merge audit pass.

## What's changed

**1. CHANGELOG**
- Backfilled the **v0.9.5** entry with **#108** (installer dirty-tree safety) â€” landed before the v0.9.5 tag but slipped from the release notes.
- Added `[Unreleased]` entry for **#111** (README Toolbox/Tools rename â€” landed AFTER the v0.9.5 tag).

**2. SKILL.md** â€” added `What's new in 0.9.3 / 0.9.4 / 0.9.5` stanzas. The body's "What's new" list stopped at 0.9.2 even though the frontmatter already advertised 0.9.5. Restores continuity for LLMs reading the operating manual.

**3. `docs/index.html:18`** â€” bumped the `AGENT-READABLE SUMMARY (v0.9.4)` stamp to v0.9.5. Everything else on the page was already v0.9.5; this comment was the only stale line that `sync-version.ts` didn't catch (unique pattern, not in the sync-version literal list).

**4. `.gitignore`** â€” added `test-runs/`. That directory accumulates ~13 MB of daemon logs, screenshots, OCR dumps, and PID files across smoke-test runs. Previously not ignored â€” a stray `git add .` would have committed all of it.

## What's not in this PR

- **`npm publish`** is not done. The post-drafts in `.claude/worktrees/release-095/test-runs/post-drafts/` were edited to drop the premature `npm i -g clawdcursor` claims; they now point at the `irm | iex` / `curl | bash` installers. (Those drafts are gitignored, so not part of this PR â€” just hand-fixed for you.)
- **MEMORY.md** was refreshed (it said "current: 0.9.4" â€” now reflects v0.9.5 + post-v0.9.5 PR queue).
- **Stale local branch / worktree cleanup** â€” deferred. Would benefit from a `git fetch --prune && git branch -vv | awk '/[gone]/{print $1}' | xargs git branch -D` pass; safe but lots of names to verify.

## Verification

- `npm run lint` 0 errors
- `npm run typecheck` clean
- `npm run typecheck:tests` clean
- `npm run test:mcp-schema-snapshot` OK
- `npm run build` clean
- `npm run test:ci` **846 / 847 pass** (1 skipped â€” the known headless-Linux orphan-teardown skip)

## Merge order

Best as: this PR â†’ #112 â†’ #118.

- This PR's `[Unreleased]` mentions only #111. After it lands, #112 needs to rebase and ADD its auth-hardening lines under the same `[Unreleased]` block. The conflict resolution is one-add-after-the-other â€” no overlap.
- #118 (Windows + Node 20 flake skip) is independent; ideally lands in `[Unreleased]` too. Trivial to add when it merges.
