### PR TITLE
feat(prompt): teach an explicit token-cost hierarchy (efficiency)

### DIFF
--- a/src/core/agent-loop/prompt.ts
+++ b/src/core/agent-loop/prompt.ts
@@ -48,9 +48,16 @@ ${visionLine}
 
 OPERATING PRINCIPLES
 1. ONE tool call per turn. The next turn shows the new screen state.
-2. PREFER a11y over clicks. invoke_element / set_field_value act by name and
-   survive DPI, window resize, and layout shifts. Use them when the snapshot
-   shows a named target.
+2. CHEAPEST TOOL THAT WORKS. Tools cost different amounts of tokens — climb
+   this ladder only when the rung below cannot answer the question:
+     act (click / type / key — near-free) <
+     inspect (find_element / get_element — small) <
+     read a11y tree or OCR (read_screen / ocr_read_screen — medium) <
+     screenshot (an image — most expensive).
+   The ranked a11y snapshot is already attached every turn — read IT before
+   spending a screenshot. As a corollary, PREFER a11y over clicks:
+   invoke_element / set_field_value act by name and survive DPI, window
+   resize, and layout shifts. Use them when the snapshot shows a named target.
 3. PREFER keyboard over mouse. key("mod+s") beats clicking a Save icon.
 4. VERIFY before declaring done. The screen must actually show the result.
    Call done() only with specific evidence ("title bar says 'Untitled*' so


### PR DESCRIPTION
Advances the **"efficiently"** dimension of the goal: clawdcursor should help any AI agent complete GUI tasks with minimal token spend.

## What
The agent system prompt (returned to external agents via `get_system_prompt`, and used by clawdcursor's own loop) encouraged "prefer a11y over clicks/screenshots" qualitatively but never named the underlying **token-cost ladder**. This makes it explicit, folded into operating principle #2:

```
act (click/type/key)            — near-free
  < inspect (find_element/get_element)        — small
  < read a11y tree / OCR (read_screen)        — medium
  < screenshot (an image)                     — most expensive
```

Agents are told to climb only when the cheaper rung can't answer, and to read the already-attached a11y snapshot before spending a screenshot.

## Why this layer
This is the **prose** layer of the cost-aware design — the highest-leverage, lowest-risk slice. The per-tool `costClass` metadata surface (Phase A, exposing cost tiers in `tools/list`) is a larger, separate step with a schema-canonicalize invariant to handle; deliberately not bundled here to keep the change safe and reviewable.

## Verification
874 tests pass / 1 skipped / 0 failed · 0 TypeScript errors · 0 lint errors. Prompt-consuming tests (`introspection`, `unified-agent`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
