### PR TITLE
chore(npm): registry metadata — mcpName + current description + keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "clawdcursor",
   "version": "0.9.7",
-  "description": "The skill that gives any AI agent a cursor and a keyboard on a real desktop. Open source (MIT). Model-agnostic — works with Claude, GPT, Gemini, Llama, or any tool-calling model — on Windows, macOS, and Linux.",
+  "mcpName": "io.github.AmrDab/clawdcursor",
+  "description": "Local MCP server that gives any AI agent safe cross-OS desktop control — the fallback execution layer for when APIs, CLIs, and direct integrations aren't available. Works with any tool-calling model (Claude, GPT, Gemini, Llama) on Windows, macOS, and Linux. Open source (MIT).",
   "homepage": "https://clawdcursor.com",
   "repository": {
     "type": "git",
@@ -15,9 +16,11 @@
     "agent",
     "ai-agent",
     "mcp",
+    "mcp-server",
     "model-context-protocol",
     "desktop-automation",
     "computer-use",
+    "gui-automation",
     "accessibility",
     "claude",
     "gpt",


### PR DESCRIPTION
Distribution/discoverability metadata, prep for the official MCP registry.

- **`mcpName: io.github.AmrDab/clawdcursor`** — required field for publishing to registry.modelcontextprotocol.io via the `mcp-publisher` CLI (namespace is GitHub-authenticated).
- **Description** — replaced the stale "skill that gives any AI agent a cursor and a keyboard" line with the current local-MCP-server / fallback-execution-layer positioning (matches repo description + README tagline). npm's package page shows this.
- **Keywords** — added `mcp-server` + `gui-automation` (Glama / PulseMCP / Smithery index npm keywords).

⚠️ Takes effect on npm only after a **republish**, and unlocks the official-registry `mcp-publisher publish` step (which needs a one-time `mcp-publisher login github`). Both queued for @AmrDab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
