### PR TITLE
feat(toolbox): expose smart_* + URI escape hatches via compound tools

### DIFF
--- a/src/core/safety.ts
+++ b/src/core/safety.ts
@@ -179,6 +179,7 @@ const TOOL_TIER: Record<string, Tier> = {
   'cdp_read_text': 'read',
   'cdp_list_tabs': 'read',
   'shortcuts_list': 'read',
+  'build_uri': 'read',          // pure string construction — no side effects
   // Input — allow with label check
   'mouse_click': 'input',
   'mouse_double_click': 'input',
@@ -255,6 +256,9 @@ const TOOL_TIER: Record<string, Tier> = {
   // v0.8.2 — Electron/WebView2 bridge tools
   'detect_webview_apps': 'read',
   'relaunch_with_cdp': 'destructive',  // closes the app — app may prompt to save
+  // URI escape hatch + guide-write — match their granular safetyTier (2).
+  'open_uri': 'destructive',    // dispatches to an arbitrary registered handler (file: can execute)
+  'learn_app': 'destructive',   // writes a guide to ~/.clawdcursor
   // Tranche 3 — compact compound MCP surface. When an agent calls one of
   // these, the real action is decided by the `action` arg (already
   // unpacked above via unpackCompoundTool for the unified-agent compound
@@ -304,6 +308,7 @@ function unpackCompoundTool(tool: string, args: Record<string, unknown>): string
       expand: 'a11y_expand', collapse: 'a11y_collapse',
       toggle: 'a11y_toggle', select: 'a11y_select', state: 'get_element_state',
       list_children: 'a11y_list_children', wait_for: 'wait_for_element',
+      smart_click: 'smart_click', smart_type: 'smart_type', smart_read: 'smart_read',
     },
     window: {
       list: 'get_windows', active: 'get_active_window', focus: 'focus_window',
@@ -321,6 +326,8 @@ function unpackCompoundTool(tool: string, args: Record<string, unknown>): string
       // v0.8.2
       detect_webview: 'detect_webview_apps',
       relaunch_with_cdp: 'relaunch_with_cdp',
+      // URI escape hatches + guide-write (added to the compound surface)
+      build_uri: 'build_uri', open_uri: 'open_uri', learn_app: 'learn_app',
     },
     browser: {
       connect: 'cdp_connect', page_context: 'cdp_page_context', read_text: 'cdp_read_text',

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -99,6 +99,11 @@ const ACCESSIBILITY_ACTIONS: ActionRoute[] = [
   { action: 'state',          delegate: 'get_element_state' },
   { action: 'list_children',  delegate: 'a11y_list_children', argRemap: { name: 'parentName' } },
   { action: 'wait_for',       delegate: 'wait_for_element' },
+  // Smart auto-fallback (OCR → a11y → CDP, by element text — no coordinates).
+  // Restores the smart_* ergonomics to the recommended compound surface.
+  { action: 'smart_click',    delegate: 'smart_click' },
+  { action: 'smart_type',     delegate: 'smart_type' },
+  { action: 'smart_read',     delegate: 'smart_read' },
 ];
 
 const WINDOW_ACTIONS: ActionRoute[] = [
@@ -137,6 +142,13 @@ const SYSTEM_ACTIONS: ActionRoute[] = [
   { action: 'detect_app',      delegate: 'detect_app' },
   { action: 'classify_task',   delegate: 'classify_task' },
   { action: 'system_prompt',   delegate: 'get_system_prompt' },
+  // URI escape hatches — accomplish an intent WITHOUT driving UI by dispatching
+  // a registered URI scheme (mailto:, tel:, slack:, vscode:, spotify:, file:, …).
+  // Cross-OS: macOS `open`, Linux `xdg-open`, Windows registered-handler resolve.
+  { action: 'build_uri',       delegate: 'build_uri' },
+  { action: 'open_uri',        delegate: 'open_uri' },
+  // Persist a learned app guide (write companion to `app_guide`, which reads).
+  { action: 'learn_app',       delegate: 'learn_app' },
 ];
 
 const BROWSER_ACTIONS: ActionRoute[] = [


### PR DESCRIPTION
Closes the Toolbox gaps found in the orphan audit — wires the genuinely-useful granular tools into the recommended 6-tool compound surface.

## Added to the Toolbox
- **`accessibility`**: `smart_click` / `smart_type` / `smart_read` — auto-fallback **OCR → a11y → CDP** by element text, no coordinates. Restores the ergonomic "click by name and it just works" path.
- **`system`**: `open_uri` / `build_uri` / `learn_app` — the **URI escape hatches** (`mailto:` `tel:` `slack:` `vscode:` `spotify:` `file:` …) that let an agent accomplish an intent *without driving UI at all*, plus `learn_app` to persist a guide.

## Cross-OS (verified per request)
- `open_uri` dispatches via macOS `open`, Linux `xdg-open`, Windows registered-handler resolution — each branch checked.
- `build_uri` is pure string construction; `smart_*` route through the PlatformAdapter. All were already cross-platform; this only changes dispatch wiring.

## Safety
- Added matching `publicCompoundMap` entries in `safety.ts` so the gate canonicalizes the new compound actions (audit log + tier lookup).
- Added `TOOL_TIER` entries so they gate correctly on the compound path: `open_uri`/`learn_app` → **destructive** (tier 2), `build_uri` → **read**. Without these they'd default to `input` — under-gating `open_uri` (which can dispatch `file:`/`vscode:`).

## Deliberately NOT done
- **`minimize_window` is kept** — it turned out to be *live* (used by the agent-loop palettes + has a tier mapping), not a dead duplicate. Deleting it would break the autonomous pipeline.
- `compactGroup` left unset on the new delegates — dispatch resolves by name (`getTool`), consistent with the `delegate_to_agent` precedent.

## Verification
874 tests pass / 1 skipped / 0 failed · typecheck clean · lint 0 errors · schema snapshot unchanged (tracks the 97 granular tools; compound enums are runtime-built). Confirmed the new actions appear in the `accessibility` + `system` action enums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
