### PR TITLE
fix(security): AppleScript backslash escaping + crypto host token (CodeQL #61-64, #77)

### DIFF
--- a/src/platform/macos.ts
+++ b/src/platform/macos.ts
@@ -365,22 +365,22 @@ export class MacOSAdapter implements PlatformAdapter {
   private buildMacWindowTargetClause(query?: { processName?: string; processId?: number; title?: string }): string {
     if (!query) return 'window 1 of (first application process whose frontmost is true)';
     if (query.processName) {
-      const safe = query.processName.replace(/"/g, '\\"');
+      const safe = query.processName.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       if (query.title) {
-        const t = query.title.replace(/"/g, '\\"');
+        const t = query.title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         return `window "${t}" of application process "${safe}"`;
       }
       return `window 1 of application process "${safe}"`;
     }
     if (query.processId !== undefined) {
       if (query.title) {
-        const t = query.title.replace(/"/g, '\\"');
+        const t = query.title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         return `window "${t}" of (first application process whose unix id is ${query.processId})`;
       }
       return `window 1 of (first application process whose unix id is ${query.processId})`;
     }
     if (query.title) {
-      const t = query.title.replace(/"/g, '\\"');
+      const t = query.title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       return `first window whose title contains "${t}" of (first application process whose frontmost is true)`;
     }
     return 'window 1 of (first application process whose frontmost is true)';

--- a/src/platform/native-helper.ts
+++ b/src/platform/native-helper.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as readline from 'readline';
+import * as crypto from 'crypto';
 import { getPackageRoot } from '../paths';
 
 const IS_MACOS = process.platform === 'darwin';
@@ -551,13 +552,20 @@ export async function stopHostApp(): Promise<void> {
 function getOrCreateHostToken(): string {
   const dir = path.join(os.homedir(), '.clawdcursor');
   const tokenPath = path.join(dir, 'host-token');
-  if (fs.existsSync(tokenPath)) {
-    return fs.readFileSync(tokenPath, 'utf-8').trim();
-  }
   fs.mkdirSync(dir, { recursive: true });
-  const token = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 18)}`;
-  fs.writeFileSync(tokenPath, token, { mode: 0o600 });
-  return token;
+  // Cryptographically-random token (Math.random is not secure for auth), written
+  // with an exclusive create ('wx') so a concurrent caller can't clobber/race the
+  // file between a check and write — if it already exists, read the existing one.
+  const token = crypto.randomBytes(24).toString('hex');
+  try {
+    fs.writeFileSync(tokenPath, token, { mode: 0o600, flag: 'wx' });
+    return token;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      return fs.readFileSync(tokenPath, 'utf-8').trim();
+    }
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes the **two genuine** vulnerabilities from a full security triage of the 22 open CodeQL alerts on `main`. The other 20 are by-design for a local single-user tool (verified) and are being dismissed with justifications.

## Fixed
### AppleScript injection — `src/platform/macos.ts` (CodeQL #61–64, HIGH)
`buildMacWindowTargetClause` escaped `"` but not `\` before embedding `processName`/`title` into an `osascript -e` double-quoted string. `\` is an AppleScript escape char and these fields are LLM/screen-supplied, so a backslash could break out of the string literal. Now escapes `\` then `"` at all 4 sites — matching the correct idiom already used elsewhere in the same file (`~579/606/644`).

### Host-helper token — `src/platform/native-helper.ts` (CodeQL #77, HIGH)
- `Math.random()` → `crypto.randomBytes(24)` (the old RNG isn't cryptographically secure for an auth token).
- `existsSync`+`writeFileSync` → exclusive create (`flag: 'wx'`) that reads the existing token on `EEXIST` — closes the TOCTOU race.

## Cross-OS
macOS path is macOS-only; the token helper uses `wx`/`crypto` (all OS). 874 tests pass, typecheck + lint clean.

## Dismissing (by-design, not fixed)
- **#65/#66** URL substring — `isAnthropic` picks API *wire-format* for the user's own configured endpoint, not an SSRF/trust gate.
- **#67–72, #75/#76** file↔network — the user's own public guide registry, loopback (`127.0.0.1`) control with the user's own token, and the opt-in redacted `report`.
- **#79/#80** FS races — read/write the user's own `~/.clawdcursor` files; no privileged target.
- **#73/#74** OCR temp — unpredictable `randomUUID` names, unlinked immediately, single-user local.
- **#90** TOCTOU in a build script; **#89** unused var in a non-shipped perf harness.
- **#55** already resolved — the workflow has a `permissions: contents: read` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
