### PR TITLE
feat(install): npm-global installer, Claude Code plugin, and dist/index.js back-compat shim

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "clawdcursor",
   "displayName": "clawdcursor — safe desktop control",
   "version": "1.5.3",
-  "description": "Safe cross-OS desktop & browser control for Claude Code — the fallback execution layer for when APIs, CLIs, and direct integrations aren't available. Registers the clawdcursor MCP server in compact mode and bundles its usage skill (the SKILL.md at the repo root). Prerequisite: the clawdcursor binary must be on PATH (npm i -g clawdcursor).",
+  "description": "Safe cross-OS desktop & browser control for Claude Code — the fallback execution layer for when APIs, CLIs, and direct integrations aren't available. Registers the clawdcursor MCP server in compact mode and bundles its usage skill (the SKILL.md at the repo root). Requires Node.js 20+; the MCP server launches via npx, which fetches clawdcursor on demand (or uses your global install if present) — no separate install step.",
   "author": {
     "name": "Amr Dabbas"
   },
@@ -19,8 +19,8 @@
   ],
   "mcpServers": {
     "clawdcursor": {
-      "command": "clawdcursor",
-      "args": ["mcp", "--compact"]
+      "command": "npx",
+      "args": ["-y", "clawdcursor", "mcp", "--compact"]
     }
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "clawdcursor",
+  "displayName": "clawdcursor — safe desktop control",
+  "version": "1.5.3",
+  "description": "Safe cross-OS desktop & browser control for Claude Code — the fallback execution layer for when APIs, CLIs, and direct integrations aren't available. Registers the clawdcursor MCP server in compact mode and bundles its usage skill (the SKILL.md at the repo root). Prerequisite: the clawdcursor binary must be on PATH (npm i -g clawdcursor).",
+  "author": {
+    "name": "Amr Dabbas"
+  },
+  "homepage": "https://clawdcursor.com",
+  "repository": "https://github.com/AmrDab/clawdcursor",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "desktop-automation",
+    "computer-use",
+    "gui-automation",
+    "accessibility",
+    "fallback"
+  ],
+  "mcpServers": {
+    "clawdcursor": {
+      "command": "clawdcursor",
+      "args": ["mcp", "--compact"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Clawd Cursor will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **Installer is now `npm i -g`, not a git-clone-and-build.** The
+  `curl … | bash` / `irm … | iex` one-liners previously cloned the repo and ran
+  `npm install` + `npm run build` on the user's machine — requiring git and a
+  full build toolchain, and diverging from the `npm i -g clawdcursor` the README
+  advertises. They now install the published package globally. macOS still gets
+  a working native helper because the package's `postinstall` builds and
+  ad-hoc-signs it (ad-hoc is `build.sh`'s default). `VERSION=vX.Y.Z` still pins,
+  now via `clawdcursor@X.Y.Z`.
+- **New Claude Code plugin** (`.claude-plugin/plugin.json`) registers the MCP
+  server (compact mode, by bin name) and bundles the root `SKILL.md` — a
+  one-step, config-free install for Claude Code. Manifest version auto-syncs via
+  `scripts/sync-version.ts`.
+
+### Fixed
+
+- **Back-compat entry point at `dist/index.js`.** v0.x shipped the CLI there;
+  v1.0 moved it to `dist/surface/cli.js`. Hosts that had hard-pinned
+  `node <pkg>/dist/index.js …` (e.g. a hand-written MCP entry in Claude Code's
+  `.claude.json`) silently broke on a routine `npm i -g clawdcursor` upgrade —
+  the MCP server just failed to start with no clear cause. A thin re-export
+  shim (`src/index.ts` → `dist/index.js`) now forwards to the real CLI, so those
+  pinned paths keep working across the move. New configs should still launch the
+  `clawdcursor` bin directly or use the Claude Code plugin, neither of which
+  pins a deep dist path.
+
 ## [1.5.3] - 2026-06-14 — edge-glow indicator + security hardening
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ That's it. Ask your agent to *"open Outlook and reply to the latest email from S
 
 > **Editor permission allowlists:** use the server-level wildcard `"mcp__clawdcursor"` rather than per-tool entries &mdash; it covers every tool and survives tool renames across versions.
 
+### Or install the Claude Code plugin (no hand-edited config)
+
+If you use **Claude Code**, you can skip the manual `mcpServers` block above. This
+repo ships a plugin (`.claude-plugin/plugin.json`) that registers the MCP server
+**and** bundles the usage skill in one step &mdash; and because it launches the
+`clawdcursor` bin by name (never a hard-coded `dist/` path), it can't be broken by
+an entry-point change on the next `npm i -g clawdcursor` upgrade.
+
+```bash
+npm i -g clawdcursor          # prerequisite: the bin must be on PATH
+clawdcursor consent --accept  # one-time desktop-control consent
+
+# load the plugin for one session straight from a checkout…
+claude --plugin-dir /path/to/clawdcursor
+# …or add this repo to a plugin marketplace for a persistent install.
+```
+
+> **Windows note:** the plugin spawns the global `clawdcursor` bin. If your Claude
+> Code build can't resolve the `.cmd` shim on `PATH`, fall back to the explicit
+> `node` form &mdash; point it at the bin entry **or** the back-compat shim
+> (`node "%APPDATA%/npm/node_modules/clawdcursor/dist/surface/cli.js" mcp --compact`).
+
 ---
 
 ## The engine

--- a/README.md
+++ b/README.md
@@ -123,23 +123,24 @@ That's it. Ask your agent to *"open Outlook and reply to the latest email from S
 
 If you use **Claude Code**, you can skip the manual `mcpServers` block above. This
 repo ships a plugin (`.claude-plugin/plugin.json`) that registers the MCP server
-**and** bundles the usage skill in one step &mdash; and because it launches the
-`clawdcursor` bin by name (never a hard-coded `dist/` path), it can't be broken by
-an entry-point change on the next `npm i -g clawdcursor` upgrade.
+**and** bundles the usage skill in one step. It launches the server with
+`npx -y clawdcursor mcp --compact`, so there's **nothing to install first** &mdash;
+npx fetches clawdcursor on demand (or uses your global install if you have one), and
+because it resolves the package's `bin` (never a hard-coded `dist/` path) it can't be
+broken by an entry-point change on upgrade.
 
 ```bash
-npm i -g clawdcursor          # prerequisite: the bin must be on PATH
-clawdcursor consent --accept  # one-time desktop-control consent
-
 # load the plugin for one session straight from a checkout…
 claude --plugin-dir /path/to/clawdcursor
 # …or add this repo to a plugin marketplace for a persistent install.
+
+# one-time desktop-control consent (npx fetches the bin if you don't have it):
+npx -y clawdcursor consent --accept
 ```
 
-> **Windows note:** the plugin spawns the global `clawdcursor` bin. If your Claude
-> Code build can't resolve the `.cmd` shim on `PATH`, fall back to the explicit
-> `node` form &mdash; point it at the bin entry **or** the back-compat shim
-> (`node "%APPDATA%/npm/node_modules/clawdcursor/dist/surface/cli.js" mcp --compact`).
+> **Requires Node.js 20+** (for `npx`, which ships with Node). The first launch
+> downloads clawdcursor into npx's cache; later launches reuse it &mdash; no global
+> install and no `PATH` shim to resolve.
 
 ---
 

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -1,10 +1,21 @@
 # Clawd Cursor Installer for Windows
 # Usage: powershell -c "irm https://clawdcursor.com/install.ps1 | iex"
 # Specify version: $env:VERSION='v1.5.3'; irm https://clawdcursor.com/install.ps1 | iex
+#
+# Installs the published npm package globally (npm i -g clawdcursor) -- no git
+# clone, no local build toolchain. Windows needs no native build step.
 
 $ErrorActionPreference = "Continue"
-$VERSION = if ($env:VERSION) { $env:VERSION } else { "main" }
-$INSTALL_DIR = "$HOME\clawdcursor"
+
+# VERSION maps to an npm dist-tag/version. The old git-branch default ("main")
+# and a leading "v" both normalise to npm's "latest"/"x.y.z" form.
+$VERSION = if ($env:VERSION) { $env:VERSION } else { "latest" }
+if ($VERSION -in @("main", "latest", "")) {
+    $PKG = "clawdcursor@latest"; $DISPLAY_VERSION = "latest"
+} else {
+    $clean = $VERSION -replace '^v', ''
+    $PKG = "clawdcursor@$clean"; $DISPLAY_VERSION = $clean
+}
 
 Write-Host ""
 Write-Host "  /\___/\" -ForegroundColor Green
@@ -27,195 +38,62 @@ if ($major -lt 20) {
 }
 Write-Host "  [OK] Node.js $nodeVersion" -ForegroundColor Green
 
-# ── 2. Check git ──────────────────────────────────────────────────────────────
-$gitVer = $null
-try { $gitVer = (git --version 2>$null) } catch {}
-if (-not $gitVer) {
-    Write-Host "  [X] git not found. Get it from https://git-scm.com" -ForegroundColor Red
+# ── 2. Install from npm ──────────────────────────────────────────────────────
+Write-Host "  Installing $PKG (global)..." -ForegroundColor Cyan
+$output = npm install -g $PKG --loglevel error 2>&1 | Out-String
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "  [X] npm install failed:" -ForegroundColor Red
+    foreach ($line in ($output -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
+    Write-Host "      Retry in an elevated terminal, or set a user-writable npm prefix." -ForegroundColor Yellow
     exit 1
 }
-Write-Host "  [OK] $gitVer" -ForegroundColor Green
 
-# ── 3. Clone or update ───────────────────────────────────────────────────────
-Write-Host ""
-$DISPLAY_VERSION = if ($VERSION -eq "main") { "latest (main)" } else { $VERSION }
-
-if (Test-Path "$INSTALL_DIR\.git") {
-    # Update existing install -- only proceed if the working tree is clean.
-    # The previous "git checkout && pull || rm -rf" path silently destroyed
-    # user state when git complained (dirty tree, diverged history, etc.).
-    Write-Host "  Updating to $DISPLAY_VERSION..." -ForegroundColor Cyan
-    Push-Location $INSTALL_DIR
-
-    $dirty = git status --porcelain 2>$null
-    if ($dirty) {
-        Pop-Location
-        Write-Host "  [X] Refusing to update: $INSTALL_DIR has uncommitted changes." -ForegroundColor Red
-        Write-Host ""
-        $dirtyLines = @($dirty -split "`r?`n" | Where-Object { $_ })
-        foreach ($line in ($dirtyLines | Select-Object -First 20)) { Write-Host "      $line" }
-        if ($dirtyLines.Count -gt 20) { Write-Host "      ... and $($dirtyLines.Count - 20) more" }
-        Write-Host ""
-        Write-Host "  Pick one and re-run the installer:" -ForegroundColor Yellow
-        Write-Host "    - Stash:    Push-Location $INSTALL_DIR; git stash; Pop-Location"
-        Write-Host "    - Discard:  Push-Location $INSTALL_DIR; git reset --hard; git clean -fd; Pop-Location"
-        Write-Host "    - Sidecar:  `$env:INSTALL_DIR='$HOME\clawdcursor-new'; irm https://clawdcursor.com/install.ps1 | iex"
-        exit 1
-    }
-
-    $fetchErr = (git fetch --all --tags --quiet 2>&1 | Out-String)
-    if ($LASTEXITCODE -ne 0) {
-        Pop-Location
-        Write-Host "  [X] Failed to fetch from GitHub (network or auth issue):" -ForegroundColor Red
-        foreach ($line in ($fetchErr -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
-        exit 1
-    }
-
-    $coErr = (git checkout $VERSION --quiet 2>&1 | Out-String)
-    if ($LASTEXITCODE -ne 0) {
-        Pop-Location
-        Write-Host "  [X] Failed to switch to '$VERSION':" -ForegroundColor Red
-        foreach ($line in ($coErr -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
-        Write-Host "      (tree is clean -- likely the ref doesn't exist on origin)"
-        exit 1
-    }
-
-    # Only pull if we landed on a branch; tag/SHA checkouts are detached.
-    git symbolic-ref -q HEAD 2>$null | Out-Null
-    if ($LASTEXITCODE -eq 0) {
-        $pullErr = (git pull --ff-only --quiet 2>&1 | Out-String)
-        if ($LASTEXITCODE -ne 0) {
-            Pop-Location
-            Write-Host "  [X] Failed to fast-forward '$VERSION':" -ForegroundColor Red
-            foreach ($line in ($pullErr -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
-            Write-Host "      Local branch may have diverged from origin. Resolve manually."
-            exit 1
-        }
-    }
-    Pop-Location
-} elseif (Test-Path $INSTALL_DIR) {
-    # Directory exists but isn't a git checkout. Could be user data we
-    # don't recognise -- refuse rather than silently Remove-Item -Force.
-    Write-Host "  [X] $INSTALL_DIR exists but is not a git checkout." -ForegroundColor Red
-    Write-Host "      Move or remove it manually, then re-run. (We won't delete"
-    Write-Host "      it for you because it might contain unrelated files.)"
-    exit 1
-} else {
-    Write-Host "  Downloading $DISPLAY_VERSION..." -ForegroundColor Cyan
-    $cloneErr = (git clone https://github.com/AmrDab/clawdcursor.git --branch $VERSION $INSTALL_DIR --quiet 2>&1 | Out-String)
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "  [X] Clone failed:" -ForegroundColor Red
-        foreach ($line in ($cloneErr -split "`r?`n" | Where-Object { $_ })) { Write-Host "      $line" }
-        exit 1
-    }
-}
-
-# ── 4. Install dependencies ──────────────────────────────────────────────────
-Write-Host "  Installing dependencies..." -ForegroundColor Cyan
-Push-Location $INSTALL_DIR
-$output = npm install --loglevel error 2>&1 | Out-String
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  [X] npm install failed. Run manually: cd $INSTALL_DIR; npm install" -ForegroundColor Red
-    Pop-Location; exit 1
-}
-
-# ── 5. Build ──────────────────────────────────────────────────────────────────
-Write-Host "  Building..." -ForegroundColor Cyan
-$output = npm run build 2>&1 | Out-String
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "  [X] Build failed. Run manually: cd $INSTALL_DIR; npm run build" -ForegroundColor Red
-    Pop-Location; exit 1
-}
-
-# ── 6. Link (with pre-cleanup to avoid EEXIST) ───────────────────────────────
-Write-Host "  Linking..." -ForegroundColor Cyan
-$npmPrefix = (npm prefix -g 2>$null)
-if ($npmPrefix) {
-    $npmPrefix = $npmPrefix.Trim()
-    # Remove old shims -- prevents EEXIST errors on re-install
-    foreach ($ext in @('', '.cmd', '.ps1')) {
-        $shimPath = "$npmPrefix\clawdcursor$ext"
-        if (Test-Path $shimPath) { Remove-Item -Force $shimPath 2>$null }
-    }
-    # Remove old junction safely (cmd rmdir won't follow into target)
-    $junctionPath = "$npmPrefix\node_modules\clawdcursor"
-    if (Test-Path $junctionPath) {
-        cmd /c "rmdir `"$junctionPath`"" 2>$null
-    }
-}
-$output = npm link --force 2>&1 | Out-String
-Pop-Location
-
-# ── 7. Verify ─────────────────────────────────────────────────────────────────
-# Refresh PATH so we can find the newly linked command
+# ── 3. Verify ─────────────────────────────────────────────────────────────────
+# Refresh PATH so we can find the newly installed command this session.
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+$npmPrefix = (npm prefix -g 2>$null)
+if ($npmPrefix) { $npmPrefix = $npmPrefix.Trim() }
 
 $exe = Get-Command clawdcursor -ErrorAction SilentlyContinue
 Write-Host ""
 if ($exe) {
     $ver = & clawdcursor --version 2>$null
     Write-Host "  [OK] Clawd Cursor $ver installed!" -ForegroundColor Green
+} elseif ($npmPrefix -and (-not ($env:Path -split ';' | Where-Object { $_ -eq $npmPrefix }))) {
+    Write-Host "  [OK] Installed, but npm's bin folder is not in your PATH." -ForegroundColor Yellow
+    Write-Host "       Add this to your PATH, then reopen your terminal:" -ForegroundColor Yellow
+    Write-Host "       $npmPrefix" -ForegroundColor White
 } else {
-    # Diagnose: is npm prefix in PATH?
-    if ($npmPrefix) {
-        $inPath = $env:Path -split ';' | Where-Object { $_ -eq $npmPrefix }
-        if (-not $inPath) {
-            Write-Host "  [OK] Installed, but npm's bin folder is not in your PATH." -ForegroundColor Yellow
-            Write-Host "       Add this to your system PATH, then reopen your terminal:" -ForegroundColor Yellow
-            Write-Host "       $npmPrefix" -ForegroundColor White
-        } else {
-            Write-Host "  [OK] Installed! Close and reopen your terminal to use 'clawdcursor'." -ForegroundColor Green
-        }
-    } else {
-        Write-Host "  [OK] Installed to $INSTALL_DIR" -ForegroundColor Green
-        Write-Host "       Reopen your terminal to use 'clawdcursor'." -ForegroundColor Yellow
-    }
+    Write-Host "  [OK] Installed! Close and reopen your terminal to use 'clawdcursor'." -ForegroundColor Green
 }
 
-# Detect whether the user already accepted consent on a prior install.
-# Saves them from being told to re-run a one-time step they already did.
+# ── 4. Next steps ──────────────────────────────────────────────────────────────
+# Detect prior consent (known path) so repeat installs don't re-prompt for it.
 $consentGiven = Test-Path "$HOME\.clawdcursor\consent"
-$configPresent = Test-Path "$INSTALL_DIR\.clawdcursor-config.json"
 
 Write-Host ""
 if (-not $consentGiven) {
     Write-Host "  Start here:" -ForegroundColor Cyan
     Write-Host "    clawdcursor consent     " -NoNewline -ForegroundColor Yellow
-    Write-Host "One-time desktop control authorization" -ForegroundColor Gray
-    Write-Host ""
-    Write-Host "  Then pick a path:" -ForegroundColor Cyan
+    Write-Host "One-time desktop-control authorization" -ForegroundColor Gray
 } else {
     Write-Host "  [OK] Consent already accepted from a previous install." -ForegroundColor Green
-    Write-Host ""
-    Write-Host "  Pick a path:" -ForegroundColor Cyan
 }
+Write-Host ""
+Write-Host "  Then pick a path:" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "    Autonomous agent" -NoNewline -ForegroundColor White
 Write-Host " (clawdcursor brings the AI brain):" -ForegroundColor Gray
-if ($configPresent) {
-    Write-Host "      Config already saved -- skip step 1 unless you want to reconfigure." -ForegroundColor DarkGray
-    Write-Host "      1. clawdcursor doctor   " -NoNewline -ForegroundColor DarkYellow
-    Write-Host "(optional) Re-check / change AI provider + models" -ForegroundColor Gray
-} else {
-    Write-Host "      1. clawdcursor doctor   " -NoNewline -ForegroundColor Yellow
-    Write-Host "Configure AI provider + models" -ForegroundColor Gray
-}
+Write-Host "      1. clawdcursor doctor   " -NoNewline -ForegroundColor Yellow
+Write-Host "Configure AI provider + models" -ForegroundColor Gray
 Write-Host "      2. clawdcursor agent    " -NoNewline -ForegroundColor Yellow
 Write-Host "Start the daemon (HTTP + MCP on :3847)" -ForegroundColor Gray
 Write-Host ""
 Write-Host "    MCP-only" -NoNewline -ForegroundColor White
 Write-Host " (your editor brings the AI brain):" -ForegroundColor Gray
-Write-Host "      Register " -NoNewline -ForegroundColor Gray
-Write-Host "clawdcursor mcp" -NoNewline -ForegroundColor Yellow
-Write-Host " with Claude Code, Cursor, Windsurf, Zed, etc." -ForegroundColor Gray
+Write-Host "      - Claude Code: install the plugin (bundles the MCP server + skill," -ForegroundColor Gray
+Write-Host "        no hand-edited config) -- see the README's plugin section." -ForegroundColor Gray
+Write-Host "      - Cursor / Windsurf / Zed: register " -NoNewline -ForegroundColor Gray
+Write-Host "clawdcursor mcp --compact" -ForegroundColor Yellow
 Write-Host "      No daemon, no API key in clawdcursor -- your editor handles both." -ForegroundColor Gray
-Write-Host ""
-Write-Host "  Run now:" -ForegroundColor White
-if (-not $consentGiven) {
-    Write-Host "    clawdcursor consent" -ForegroundColor Yellow
-} elseif (-not $configPresent) {
-    Write-Host "    clawdcursor doctor" -ForegroundColor Yellow
-} else {
-    Write-Host "    clawdcursor agent" -ForegroundColor Yellow
-}
 Write-Host ""

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -2,12 +2,22 @@
 # Clawd Cursor Installer for macOS / Linux
 # Usage: curl -fsSL https://clawdcursor.com/install.sh | bash
 # Specify version: VERSION=v1.5.3 curl -fsSL https://clawdcursor.com/install.sh | bash
+#
+# Installs the published npm package globally (npm i -g clawdcursor) — no git
+# clone, no local build toolchain. On macOS the package's postinstall builds
+# and ad-hoc-signs the native helper from source automatically (needs the Xcode
+# command-line tools; the install continues and tells you how to finish if not).
 
 set -e
-set -o pipefail  # Capture failures in pipelines (critical for build error detection)
+set -o pipefail
 
-VERSION="${VERSION:-main}"
-INSTALL_DIR="$HOME/clawdcursor"
+# VERSION maps to an npm dist-tag/version. The old git-branch default ("main")
+# and a leading "v" both normalise to npm's "latest"/"x.y.z" form.
+VERSION="${VERSION:-latest}"
+case "$VERSION" in
+  main|latest|"") PKG="clawdcursor@latest"; DISPLAY_VERSION="latest" ;;
+  *)              PKG="clawdcursor@${VERSION#v}"; DISPLAY_VERSION="${VERSION#v}" ;;
+esac
 
 echo ""
 echo "  /\___/\\"
@@ -28,267 +38,59 @@ if [ "$NODE_MAJOR" -lt 20 ]; then
 fi
 echo "  ✅ Node.js $(node --version)"
 
-# ── 2. Check git ──────────────────────────────────────────────────────────────
-if ! command -v git &>/dev/null; then
-    echo "  ❌ git not found. Install: brew install git (macOS) or sudo apt install git (Linux)"
+# ── 2. Install from npm ──────────────────────────────────────────────────────
+echo "  📦 Installing $PKG (global)..."
+if ! npm install -g "$PKG" --loglevel error; then
+    echo ""
+    echo "  ❌ npm install failed."
+    echo "     If it was a permissions (EACCES) error, either:"
+    echo "       • set a user-writable npm prefix:  npm config set prefix ~/.npm-global"
+    echo "         then add ~/.npm-global/bin to your PATH and re-run, or"
+    echo "       • re-run with elevated privileges:  sudo npm install -g $PKG"
     exit 1
 fi
-echo "  ✅ $(git --version)"
 
-# ── 3. Clone or update ───────────────────────────────────────────────────────
-echo ""
-DISPLAY_VERSION="$VERSION"
-[ "$VERSION" = "main" ] && DISPLAY_VERSION="latest (main)"
-
-ERR_LOG=$(mktemp -t clawd-installer.XXXXXX 2>/dev/null || echo "/tmp/clawd-installer-$$.log")
-trap 'rm -f "$ERR_LOG"' EXIT
-indent_err() { sed 's/^/      /' "$ERR_LOG"; }
-
-if [ -d "$INSTALL_DIR/.git" ]; then
-    # Update existing install — only proceed if the working tree is clean.
-    # The previous "git checkout && pull || rm -rf" path silently destroyed
-    # user state when git complained (dirty tree, diverged history, etc.).
-    echo "  📦 Updating to $DISPLAY_VERSION..."
-    cd "$INSTALL_DIR"
-
-    DIRTY=$(git status --porcelain 2>/dev/null)
-    if [ -n "$DIRTY" ]; then
-        echo "  ❌ Refusing to update: $INSTALL_DIR has uncommitted changes."
-        echo ""
-        echo "$DIRTY" | head -20 | sed 's/^/      /'
-        DIRTY_COUNT=$(echo "$DIRTY" | wc -l | tr -d ' ')
-        [ "$DIRTY_COUNT" -gt 20 ] && echo "      ... and $((DIRTY_COUNT - 20)) more"
-        echo ""
-        echo "  Pick one and re-run the installer:"
-        echo "    • Stash:      cd $INSTALL_DIR && git stash"
-        echo "    • Discard:    cd $INSTALL_DIR && git reset --hard && git clean -fd"
-        echo "    • Sidecar:    INSTALL_DIR=\$HOME/clawdcursor-new curl -fsSL https://clawdcursor.com/install.sh | bash"
-        exit 1
-    fi
-
-    if ! git fetch --all --tags --quiet 2>"$ERR_LOG"; then
-        echo "  ❌ Failed to fetch from GitHub (network or auth issue):"
-        indent_err
-        exit 1
-    fi
-
-    if ! git checkout "$VERSION" --quiet 2>"$ERR_LOG"; then
-        echo "  ❌ Failed to switch to '$VERSION':"
-        indent_err
-        echo "      (tree is clean — likely the ref doesn't exist on origin)"
-        exit 1
-    fi
-
-    # Only pull if we landed on a branch — tag/SHA checkouts are detached.
-    if git symbolic-ref -q HEAD >/dev/null 2>&1; then
-        if ! git pull --ff-only --quiet 2>"$ERR_LOG"; then
-            echo "  ❌ Failed to fast-forward '$VERSION':"
-            indent_err
-            echo "      Local branch may have diverged from origin. Resolve manually."
-            exit 1
-        fi
-    fi
-elif [ -d "$INSTALL_DIR" ]; then
-    # Directory exists but isn't a git checkout. Could be user data we
-    # don't recognise — refuse rather than silently rm -rf.
-    echo "  ❌ $INSTALL_DIR exists but is not a git checkout."
-    echo "      Move or remove it manually, then re-run. (We won't delete"
-    echo "      it for you because it might contain unrelated files.)"
-    exit 1
-else
-    echo "  📦 Downloading $DISPLAY_VERSION..."
-    if ! git clone https://github.com/AmrDab/clawdcursor.git --branch "$VERSION" "$INSTALL_DIR" --quiet 2>"$ERR_LOG"; then
-        echo "  ❌ Clone failed:"
-        indent_err
-        exit 1
-    fi
-fi
-
-# ── 4. Install dependencies ──────────────────────────────────────────────────
-echo "  📦 Installing dependencies..."
-cd "$INSTALL_DIR"
-npm install --loglevel error 2>/dev/null
-
-# ── 5. Build ──────────────────────────────────────────────────────────────────
-echo "  🔨 Building..."
-npm run build 2>/dev/null
-
-# ── 5b. Build native macOS host app (REQUIRED on macOS) ──────────────────────
+# ── 3. macOS native helper note ──────────────────────────────────────────────
+# The npm postinstall already built + ad-hoc-signed the helper. TCC permissions
+# still need a human click; `clawdcursor grant` walks you through them.
 if [ "$(uname)" = "Darwin" ]; then
-    NATIVE_HOST="$INSTALL_DIR/native/ClawdCursor.app/Contents/MacOS/ClawdCursorHost"
-    PERM_CHECK="$INSTALL_DIR/native/ClawdCursor.app/Contents/MacOS/permission-check"
-    BUILD_LOG="/tmp/clawdcursor-build-$$.log"
-    
-    # Check Swift is available
-    if ! command -v swift &>/dev/null; then
-        echo ""
-        echo "  ❌ Swift not found — REQUIRED for macOS"
-        echo ""
-        echo "     Install Xcode Command Line Tools:"
-        echo "       xcode-select --install"
-        echo ""
-        echo "     Then re-run the installer."
-        exit 1
-    fi
-    
-    echo "  🔨 Building macOS native host app..."
-    cd "$INSTALL_DIR/native"
-    
-    # Build with ad-hoc signing (CRITICAL for TCC on macOS 26+)
-    # Use temp file to capture exit status properly (bash pipeline bug workaround)
-    set +e  # Don't exit on error, we'll handle it
-    bash ./build.sh --adhoc > "$BUILD_LOG" 2>&1
-    BUILD_EXIT=$?
-    set -e
-    
-    # Show build output (indented)
-    if [ -f "$BUILD_LOG" ]; then
-        while IFS= read -r line; do echo "     $line"; done < "$BUILD_LOG"
-        rm -f "$BUILD_LOG"
-    fi
-    
-    # Check build exit status
-    if [ $BUILD_EXIT -ne 0 ]; then
-        echo ""
-        echo "  ❌ Native host app build FAILED (exit code $BUILD_EXIT)"
-        echo ""
-        echo "     This is REQUIRED for macOS. Common fixes:"
-        echo "       • Install Xcode Command Line Tools: xcode-select --install"
-        echo "       • Update macOS/Xcode: softwareupdate --install -a"
-        echo "       • Check build errors above"
-        echo ""
-        echo "     Manual build:"
-        echo "       cd $INSTALL_DIR/native && bash ./build.sh --adhoc"
-        exit 1
-    fi
-    
-    # Verify ALL required binaries exist
-    NATIVE_APP_DIR="$INSTALL_DIR/native/ClawdCursor.app/Contents/MacOS"
-    MISSING_BINS=""
-    for bin in ClawdCursorHost clawdcursor-helper screenshot-helper permission-check; do
-        if [ ! -f "$NATIVE_APP_DIR/$bin" ]; then
-            MISSING_BINS="$MISSING_BINS $bin"
-        fi
-    done
-    if [ -n "$MISSING_BINS" ]; then
-        echo ""
-        echo "  ❌ Build succeeded but required binaries are missing:$MISSING_BINS"
-        echo ""
-        echo "     Try rebuilding manually:"
-        echo "       cd $INSTALL_DIR/native && bash ./build.sh --adhoc"
-        exit 1
-    fi
-    
-    # Verify code signing (critical for TCC)
-    if ! codesign -v "$INSTALL_DIR/native/ClawdCursor.app" 2>/dev/null; then
-        echo ""
-        echo "  ⚠️  App not code signed — TCC permissions may not work"
-        echo "     Attempting ad-hoc signing..."
-        if codesign --sign - --force "$INSTALL_DIR/native/ClawdCursor.app" 2>/dev/null; then
-            echo "  ✅ Ad-hoc signed successfully"
-        else
-            echo "  ⚠️  Signing failed — you may need to grant permissions manually"
-        fi
-    fi
-    
-    # Quick TCC check (non-blocking, just informational)
-    if [ -f "$PERM_CHECK" ]; then
-        echo "  🔍 Checking TCC permissions..."
-        PERM_OUT=$("$PERM_CHECK" 2>/dev/null || true)
-        if echo "$PERM_OUT" | grep -q '"accessibility":true'; then
-            echo "     ✅ Accessibility: granted"
-        else
-            echo "     ⚠️  Accessibility: not yet granted"
-            echo "        → System Settings → Privacy & Security → Accessibility → enable ClawdCursor"
-        fi
-        if echo "$PERM_OUT" | grep -q '"screenRecording":true'; then
-            echo "     ✅ Screen Recording: granted"
-        else
-            echo "     ⚠️  Screen Recording: not yet granted"
-            echo "        → System Settings → Privacy & Security → Screen & System Audio Recording → enable ClawdCursor"
-        fi
-    fi
-    
-    echo "  ✅ Native host app built and signed"
-    cd "$INSTALL_DIR"
+    echo "  🍎 macOS: grant Accessibility + Screen Recording when prompted —"
+    echo "     run:  clawdcursor grant"
 fi
 
-# ── 6. Link ───────────────────────────────────────────────────────────────────
-echo "  🔗 Linking..."
-npm link --force 2>/dev/null || true
-
-# ── 7. Verify ─────────────────────────────────────────────────────────────────
+# ── 4. Verify ─────────────────────────────────────────────────────────────────
 echo ""
-
-# Final macOS verification: ensure all native binaries exist
-if [ "$(uname)" = "Darwin" ]; then
-    NATIVE_APP_DIR="$INSTALL_DIR/native/ClawdCursor.app/Contents/MacOS"
-    FINAL_MISSING=""
-    for bin in ClawdCursorHost clawdcursor-helper screenshot-helper permission-check; do
-        [ ! -f "$NATIVE_APP_DIR/$bin" ] && FINAL_MISSING="$FINAL_MISSING $bin"
-    done
-    if [ -n "$FINAL_MISSING" ]; then
-        echo "  ❌ INSTALLATION INCOMPLETE"
-        echo ""
-        echo "     Missing native binaries:$FINAL_MISSING"
-        echo "     These are required for clawdcursor to work on macOS."
-        echo ""
-        echo "     Try rebuilding manually:"
-        echo "       cd $INSTALL_DIR/native && bash ./build.sh"
-        echo ""
-        exit 1
-    fi
-fi
-
 if command -v clawdcursor &>/dev/null; then
-    echo "  ✅ Clawd Cursor $(clawdcursor --version 2>/dev/null || echo $VERSION) installed!"
+    echo "  ✅ Clawd Cursor $(clawdcursor --version 2>/dev/null || echo "$DISPLAY_VERSION") installed!"
 else
     NPM_PREFIX="$(npm prefix -g 2>/dev/null)/bin"
-    if ! echo "$PATH" | tr ':' '\n' | grep -qx "$NPM_PREFIX"; then
-        echo "  ✅ Installed, but npm's bin folder is not in your PATH."
-        echo "     Add this to your shell profile (~/.bashrc or ~/.zshrc):"
-        echo "       export PATH=\"$NPM_PREFIX:\$PATH\""
-    else
-        echo "  ✅ Installed! Reopen your terminal to use 'clawdcursor'."
-    fi
+    echo "  ✅ Installed, but npm's global bin folder isn't on your PATH."
+    echo "     Add this to your shell profile (~/.bashrc or ~/.zshrc):"
+    echo "       export PATH=\"$NPM_PREFIX:\$PATH\""
+    echo "     then reopen your terminal."
 fi
 
-# Detect prior state so we don't tell the user to re-run one-time steps
-# they already completed (consent, doctor config).
+# ── 5. Next steps ──────────────────────────────────────────────────────────────
+# Detect prior consent (known path) so repeat installs don't re-prompt for it.
 CONSENT_FILE="$HOME/.clawdcursor/consent"
-CONFIG_FILE="$INSTALL_DIR/.clawdcursor-config.json"
 
 echo ""
 if [ ! -f "$CONSENT_FILE" ]; then
     echo "  Start here:"
-    echo "    clawdcursor consent     One-time desktop control authorization"
-    echo ""
-    echo "  Then pick a path:"
+    echo "    clawdcursor consent     One-time desktop-control authorization"
 else
     echo "  [OK] Consent already accepted from a previous install."
-    echo ""
-    echo "  Pick a path:"
 fi
 echo ""
+echo "  Then pick a path:"
+echo ""
 echo "    Autonomous agent (clawdcursor brings the AI brain):"
-if [ -f "$CONFIG_FILE" ]; then
-    echo "      Config already saved — skip step 1 unless you want to reconfigure."
-    echo "      1. clawdcursor doctor   (optional) Re-check / change AI provider + models"
-else
-    echo "      1. clawdcursor doctor   Configure AI provider + models"
-fi
+echo "      1. clawdcursor doctor   Configure AI provider + models"
 echo "      2. clawdcursor agent    Start the daemon (HTTP + MCP on :3847)"
 echo ""
 echo "    MCP-only (your editor brings the AI brain):"
-echo "      Register \`clawdcursor mcp\` with Claude Code, Cursor, Windsurf, Zed, etc."
+echo "      • Claude Code: install the plugin (bundles the MCP server + skill,"
+echo "        no hand-edited config) — see the README's plugin section."
+echo "      • Cursor / Windsurf / Zed: register \`clawdcursor mcp --compact\`."
 echo "      No daemon, no API key in clawdcursor — your editor handles both."
-echo ""
-echo "  Run now:"
-if [ ! -f "$CONSENT_FILE" ]; then
-    echo "    clawdcursor consent"
-elif [ ! -f "$CONFIG_FILE" ]; then
-    echo "    clawdcursor doctor"
-else
-    echo "    clawdcursor agent"
-fi
 echo ""

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -67,6 +67,16 @@ const TARGETS: SyncTarget[] = [
     desc: 'server.json registry manifest versions (server + npm package)',
   },
 
+  // .claude-plugin/plugin.json — the Claude Code plugin manifest. Wraps the
+  // same npm release; a stale version here makes the plugin advertise the
+  // wrong version to plugin hosts.
+  {
+    file: '.claude-plugin/plugin.json',
+    pattern: /("version":\s*")\d+\.\d+\.\d+(")/,
+    replacement: `$1${VERSION}$2`,
+    desc: 'Claude Code plugin manifest version',
+  },
+
   // docs/index.html — marketing site. Several places, all distinct contexts.
   {
     file: 'docs/index.html',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+/**
+ * Back-compat entry point — DO NOT add logic here.
+ *
+ * v0.x published the CLI at `dist/index.js`. v1.0 moved the real entry to
+ * `dist/surface/cli.js` (see package.json "bin"). Some users had hard-pinned
+ * `node <pkg>/dist/index.js <args>` into an MCP host config — e.g. Claude
+ * Code's `.claude.json` — and a routine `npm i -g clawdcursor` upgrade then
+ * silently broke their launch, because the file they pointed at no longer
+ * existed. The MCP server simply failed to start with no obvious cause.
+ *
+ * This shim re-runs the real CLI so those pinned paths keep working across the
+ * move. `surface/cli` calls `program.parse()` on load, so importing it here is
+ * enough — the original `process.argv` flows straight through.
+ *
+ * New configs should launch the `clawdcursor` bin directly
+ * (`"command": "clawdcursor", "args": ["mcp", "--compact"]`) or install the
+ * Claude Code plugin, both of which resolve through npm and never pin a deep
+ * dist path. See README.md / SKILL.md.
+ */
+import './surface/cli';

--- a/tests/version-drift.test.ts
+++ b/tests/version-drift.test.ts
@@ -44,13 +44,18 @@ describe('version drift guard', () => {
   // release. If any of them drifts, fail the build and tell the dev to run
   // the sync. Keeps `npm version <bump>` honest even if its lifecycle hook
   // is bypassed (e.g. someone hand-edits package.json).
-  it('SKILL.md + docs/ + install scripts match package.json version', () => {
+  it('SKILL.md + docs/ + install scripts + plugin.json match package.json version', () => {
     const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')) as { version: string };
     const needle = pkg.version;
 
     const skill = readFileSync(join(ROOT, 'SKILL.md'), 'utf-8');
     const skillMatch = skill.match(/^version:\s*(\d+\.\d+\.\d+)/m);
     expect(skillMatch?.[1], 'SKILL.md frontmatter version drifted; run `npm run sync-version`').toBe(needle);
+
+    // .claude-plugin/plugin.json — synced by sync-version; guard it like the rest.
+    const plugin = readFileSync(join(ROOT, '.claude-plugin', 'plugin.json'), 'utf-8');
+    const pluginMatch = plugin.match(/"version":\s*"(\d+\.\d+\.\d+)"/);
+    expect(pluginMatch?.[1], '.claude-plugin/plugin.json version drifted; run `npm run sync-version`').toBe(needle);
 
     const indexHtml = readFileSync(join(ROOT, 'docs', 'index.html'), 'utf-8');
     // The <title>, meta description, and og:title are intentionally version-FREE


### PR DESCRIPTION
## Why

A hand-written MCP config that pinned `node <pkg>/dist/index.js` silently broke on a routine `npm i -g clawdcursor` upgrade, because the v1.0 entry-point move to `dist/surface/cli.js` orphaned that path. This PR fixes that class of fragility and cleans up the install/distribution story around it.

## What

**1. Back-compat entry shim — `src/index.ts` → `dist/index.js`**
Re-runs the real CLI (`surface/cli` calls `program.parse()` on load), so any host still pinning the old `dist/index.js` path keeps working across the move. Verified byte-identical to the bin on the `mcp` path.

**2. Claude Code plugin — `.claude-plugin/plugin.json`**
Registers the MCP server **by bin name** (`clawdcursor mcp --compact`, so it can't be broken by an entry-path refactor) and bundles the root `SKILL.md`. One-step, config-free install for Claude Code — no hand-edited `mcpServers` block. Manifest version is kept in sync by `scripts/sync-version.ts` (new target added).

**3. Installer reform — `docs/install.sh` + `docs/install.ps1`**
The `curl … | bash` / `irm … | iex` one-liners now `npm install -g clawdcursor` instead of git-clone + `npm install` + `npm run build`. This drops the git + build-toolchain requirement and matches the install the README already advertises. macOS still gets a built **and ad-hoc-signed** native helper via the package `postinstall` (ad-hoc is `build.sh`'s default, so no TCC regression). `VERSION=vX.Y.Z` pinning is preserved (now `clawdcursor@X.Y.Z`).

Net: **−212 lines** — most of it the removal of fragile clone/build logic from the installers.

## Validation

- `tsc` build clean; `node dist/index.js --version` → `1.5.3`; `node dist/index.js mcp --help` is `diff`-identical to the bin.
- `bash -n docs/install.sh` and the PowerShell parser both pass on the rewritten installers.
- `tsx scripts/sync-version.ts` matches all targets including the new plugin manifest.

## Notes

- `#3` from the planning discussion (collapsing a duplicate curl capability surface onto MCP) was investigated and found **already done** in 1.5.3 — MCP is the sole capability surface — so it's intentionally not part of this PR.
- CHANGELOG updated under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)