### PR TITLE
chore: v1.5.7 — UI-map accuracy reframe + repo polish

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "clawdcursor",
       "source": "./",
       "description": "Safe cross-OS desktop & browser control — the fallback execution layer for when APIs, CLIs, and direct integrations aren't available. Registers the clawdcursor MCP server (compact tool surface) and bundles its usage skill. Launches via npx, so no separate install step is required.",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "homepage": "https://clawdcursor.com",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawdcursor",
   "displayName": "clawdcursor — safe desktop control",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Safe cross-OS desktop & browser control for Claude Code — the fallback execution layer for when APIs, CLIs, and direct integrations aren't available. Registers the clawdcursor MCP server in compact mode and bundles its usage skill (the SKILL.md at the repo root). Requires Node.js 20+; the MCP server launches via npx, which fetches clawdcursor on demand (or uses your global install if present) — no separate install step.",
   "author": {
     "name": "Amr Dabbas"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,15 +1,1 @@
-# Force LF for files compared byte-for-byte by tooling, so Windows
-# autocrlf=true checkouts don't break tests that hash-compare against
-# content written with explicit '\n' separators.
-schema.snapshot.json text eol=lf
-
-# JSON files generally — keep stable across platforms.
-*.json text eol=lf
-
-# Shell scripts must stay LF on every platform (CRLF breaks /usr/bin/env
-# shebangs and bash heredocs).
-*.sh text eol=lf
-
-# Other text files: let git normalize on commit, check out with the
-# platform's native EOL.
-* text=auto
+* text=auto eol=lf

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
   workflow_dispatch:
 
@@ -14,10 +13,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: cross-platform-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify:
     name: ${{ matrix.os }} / Node ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to Clawd Cursor will be documented in this file.
 
+## [1.5.7] - 2026-06-26 — accuracy + repo polish
+
+Documentation-and-hygiene release; no runtime behavior change.
+
+### Changed
+
+- **Reframed the perception story around the UI State Compiler.** README, website
+  (`docs/index.html` + `llms.txt`), and `SKILL.md` now say what clawdcursor
+  actually does: it **compiles the screen into one fused UI map** (accessibility
+  tree + OCR, elements with stable `el_NN` ids) and acts on elements **by id** —
+  dropping to the **screenshot/vision tier** (live pixel coords off the current
+  frame) only as a last resort, for canvas-only or custom-drawn UIs. Replaces the
+  old "reads the a11y tree, screenshots as fallback" framing.
+- **Fixed a cost-tier inaccuracy in `SKILL.md`:** "screenshot" and "vision" were
+  listed as two tiers (they're one — the only tier that puts pixels in the model),
+  and `smart_read`/`smart_click`/`smart_type` were mis-filed under vision when
+  they're OCR-backed. Now a correct 3-tier ladder (structured → OCR → screenshot).
+
+### Repo hygiene
+
+- ESLint is now **0 warnings** (was 16): removed dead imports + stale
+  `eslint-disable` directives, fixed useless escapes, and documented the
+  intentional control-char sanitisers at source.
+- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1), `.editorconfig`, and
+  `.gitattributes` (`eol=lf` — line-ending hygiene for a cross-OS project).
+- CI (`cross-platform.yml`): added a `concurrency` group (cancel in-progress PR
+  runs) and a 30-minute job timeout; dropped the dead `master` push trigger.
+
 ## [1.5.6] - 2026-06-25 — straight-line cross-OS onboarding + HiDPI clicks
 
 The theme is **an agent can install clawdcursor and actually take control** — the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,131 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported via a GitHub issue or the project Discord (linked in the README).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct/][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Clawd Cursor</h1>
 
 <p align="center">
-  <strong>Safe desktop control for any AI agent.</strong> Reads the screen through the accessibility tree (screenshots as fallback),<br>
+  <strong>Safe desktop control for any AI agent.</strong> Compiles the screen into a UI map and acts on elements by stable id (screenshot/vision only as a last resort),<br>
   <strong>verifies its own actions</strong>, and gates everything through one safety checkpoint. Local &middot; cross-OS &middot; any model.
 </p>
 
@@ -43,7 +43,7 @@
 
 Clawd Cursor is a **local MCP server** that gives any tool-calling agent &mdash; Claude Code, Cursor, Windsurf, OpenClaw, the Claude Agent SDK, or your own loop &mdash; safe control of the **real desktop**. It clicks, types, reads the screen, opens apps, and drives any GUI the way a human would: native apps, the browser, even a canvas.
 
-Most "let an agent use the computer" tools take a screenshot and feed it to a vision model &mdash; slow, expensive, and brittle. Clawd Cursor reads the **accessibility tree** first (structured text, near-free, no vision model), falls back to OCR, and only reaches for pixels as a last resort. The result is cheaper, faster, private, and &mdash; uniquely &mdash; it **checks that each action actually did what it claimed**.
+Most "let an agent use the computer" tools take a screenshot and feed it to a vision model &mdash; slow, expensive, and brittle. Clawd Cursor **compiles the screen into one UI map**: it fuses the accessibility tree and OCR into a confidence-scored set of elements, each tagged with a stable `el_NN` id, and acts on elements by id &mdash; not pixel coordinates. Coordinates appear only in the last-resort screenshot/vision tier (live pixels off the current frame), for canvas-only apps or tasks that genuinely need spatial reasoning. The result is cheaper, faster, private, and &mdash; uniquely &mdash; it **checks that each action actually did what it claimed**.
 
 > **If a human can do it on a screen, your agent can too.** No API, no integration, no problem &mdash; only the right sequence of reads, clicks, keys, and waits. Use it as the **last-mile fallback**: native API exists? Use it. CLI? Use it. Clawd Cursor is for the click, the legacy app, the GUI with no public surface.
 
@@ -57,7 +57,7 @@ The desktop-agent space is crowded. The closest **install-and-go** peers are [Wi
 |------------------------------------------|:-----------------------:|:-----------:|:--------------:|:--------------------:|:------------:|
 | Any desktop app, not just the web        | ✅                      | web only    | web only       | ✅                    | ✅           |
 | Cross-OS (Windows + macOS + Linux)       | ✅                      | &mdash;     | &mdash;        | varies               | sandbox      |
-| Perception **without a vision model**    | ✅ a11y → OCR → vision  | DOM         | a11y tree      | ❌ vision-centric     | ❌ vision    |
+| Perception **without a vision model**    | ✅ compiled a11y + OCR map | DOM      | a11y tree      | ❌ vision-centric     | ❌ vision    |
 | **Verifies its own actions** (deviation) | ✅                      | &mdash;     | &mdash;        | &mdash;              | &mdash;      |
 | Single safety chokepoint (allow/confirm/block) | ✅                | &mdash;     | &mdash;        | &mdash;              | &mdash;      |
 | Any model / vendor                       | ✅                      | ✅          | not an agent   | model-specific       | Claude only  |
@@ -170,7 +170,7 @@ The perception + verification core (the **UI State Compiler**, since v1.5.0):
 
 > Set-of-Mark-style element IDs and a11y/OCR fusion aren't new ideas on their own &mdash; what's rare is doing them **locally, a11y-first (no vision model required), with a built-in verification gate and one safety chokepoint**, across three operating systems, behind a single MCP config.
 
-See the [changelog](CHANGELOG.md) for the full release history (latest: **v1.5.2** &mdash; perception reliability, honest verification, the control banner).
+See the [changelog](CHANGELOG.md) for the full release history, or the [latest release](https://github.com/AmrDab/clawdcursor/releases/latest).
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdcursor
-version: 1.5.6
+version: 1.5.7
 description: >
   FALLBACK ONLY — do not invoke unless you have already ruled out (1) a
   native API (Gmail API, GitHub API, Slack API …), (2) a CLI (git, gh,
@@ -111,10 +111,9 @@ than the granular surface - so small models (Haiku, Kimi, Ollama) stay focused.
 
 | Tier | Label | Cost | Use when |
 |---|---|---|---|
-| T1 | **structured** | ~free | Default. `accessibility.*`, `window.*`, `browser.read_text`, clipboard. Returns structured text - no image, no vision LLM. |
-| T2 | **ocr** | cheap | A11y tree is empty or sparse. `system({"action":"ocr"})` - OS-level OCR, text out, no LLM vision. |
-| T3 | **screenshot** | medium | OCR isn't enough and you need pixel context. `computer({"action":"screenshot"})` - sends an image into the LLM context. Use sparingly. |
-| T4 | **vision** | expensive | Screen is canvas-only (Paint, Figma, games) or the task requires spatial reasoning that text cannot express. `smart_click`, `smart_read`, `smart_type`. Last resort. |
+| T1 | **structured** | ~free | Default. `accessibility.*`, `window.*`, `browser.read_text`, clipboard. Returns structured text — no image, no vision model. |
+| T2 | **OCR** | cheap | A11y tree is empty or sparse. `system({"action":"ocr"})`, plus `smart_read` / `smart_click` / `smart_type` — all OCR-backed (text out, no image into the model). |
+| T3 | **screenshot / vision** | expensive | Canvas-only apps (Paint, Figma, games) or a task needing spatial reasoning text can't express. `computer({"action":"screenshot"})` puts the current frame into the model's context; you then act on live pixel coords off that frame. "Screenshot" and "vision" are the same tier — the only one that sends pixels to the model. Last resort. |
 
 **Rule: start at T1. Escalate to the next tier only when the current one fails.** Apply this logic when calling compound tools directly; the built-in agent loop (via `task({...})`) follows the same discipline.
 
@@ -263,7 +262,7 @@ clawdcursor agent
 
 ### Autonomous-agent mode
 
-Configure an LLM via `clawdcursor doctor`, then use `submit_task` / `agent_status` / `abort_task` on the granular surface (or `task({...})` on the compact surface) to hand off a plain-English task. The built-in loop perceives the desktop (a11y → OCR → screenshot), acts, and iterates until done or the turn budget is exhausted. See the Modes table above.
+Configure an LLM via `clawdcursor doctor`, then use `submit_task` / `agent_status` / `abort_task` on the granular surface (or `task({...})` on the compact surface) to hand off a plain-English task. The built-in loop compiles the screen (a11y tree + OCR, with screenshot/vision only as last resort), acts on stable element ids, and iterates until done or the turn budget is exhausted. See the Modes table above.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>clawdcursor — safe desktop control for any AI agent</title>
-  <meta name="description" content="Local MCP server that gives any AI agent safe desktop control. Reads the screen through the accessibility tree (screenshots as fallback), verifies its own actions, routes everything through one safety gate. Windows · macOS · Linux. No cloud.">
+  <meta name="description" content="Local MCP server that gives any AI agent safe desktop control. Compiles the screen into a UI map (a11y tree + OCR) with stable element ids, acts by id not by pixel, verifies its own actions, routes everything through one safety gate. Windows · macOS · Linux. No cloud.">
   <meta property="og:title" content="clawdcursor — It sees. It acts. It verifies.">
-  <meta property="og:description" content="Safe desktop control for any AI agent. Accessibility-first, verifies its own actions, one safety gate. Local · cross-OS · any model.">
+  <meta property="og:description" content="Safe desktop control for any AI agent. Compiles the screen into a UI map, acts on stable element ids, verifies its own actions, one safety gate. Local · cross-OS · any model.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://clawdcursor.com/">
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -14,7 +14,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
   <!--
-    AGENT-READABLE SUMMARY (v1.5.6)
+    AGENT-READABLE SUMMARY (v1.5.7)
     clawdcursor: the local MCP server that gives any agent safe desktop control.
 
     ── WHAT IT IS ──────────────────────────────────────────────────────────────
@@ -443,9 +443,9 @@
 
   <!-- Hero -->
   <div class="hero">
-    <div class="hero-badge"><div class="pulse"></div> v1.5.6 — latest stable</div>
+    <div class="hero-badge"><div class="pulse"></div> v1.5.7 — latest stable</div>
     <h1>It sees. It acts. It verifies.<br><span class="gr">Desktop control for any AI agent</span></h1>
-    <p>Reads the screen through the accessibility tree &mdash; screenshots only as a fallback &mdash; verifies every action actually took, and routes everything through one safety gate. Any model, any app, local, no telemetry.</p>
+    <p>Compiles the screen into one fused UI map (accessibility tree + OCR) and acts on stable element ids that survive layout shifts &mdash; dropping to screenshot/vision only for canvas-only apps. Verifies every action actually took, and routes everything through one safety gate. Any model, any app, local, no telemetry.</p>
     <div class="hero-btns">
       <a href="https://github.com/AmrDab/clawdcursor" class="btn-p" id="star-btn">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -553,8 +553,8 @@
     <div class="pipe-flow">
       <div class="pipe-step router">
         <h4><span class="pipe-num">1</span> Compile the screen</h4>
-        <span class="pipe-tag">Zero pixels</span>
-        <p>Fuse the a11y tree (+ OCR) into one el_NN map. Act on an element by id — no image bytes to the LLM; screenshots stay a fallback.</p>
+        <span class="pipe-tag">No vision model</span>
+        <p>Fuse the a11y tree + OCR into one confidence-scored el_NN map. Act on an element by stable id — no image bytes to the model. The screenshot/vision tier is last resort only.</p>
       </div>
       <div class="pipe-arrow" aria-hidden="true">→</div>
       <div class="pipe-step agent">
@@ -753,7 +753,7 @@ clawdcursor uninstall        <span style="color:var(--text3)"># remove all clawd
 </div>
 
 <footer>
-  <p>clawd<strong>cursor</strong> v1.5.6 · localhost only · MIT ·
+  <p>clawd<strong>cursor</strong> v1.5.7 · localhost only · MIT ·
     <a href="https://clawdcursor.com">Home</a> ·
     <a href="https://github.com/AmrDab/clawdcursor">GitHub</a> ·
     <a href="https://github.com/AmrDab/clawdcursor/blob/main/CHANGELOG.md">Changelog</a> ·

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -1,6 +1,6 @@
 # Clawd Cursor Installer for Windows
 # Usage: powershell -c "irm https://clawdcursor.com/install.ps1 | iex"
-# Specify version: $env:VERSION='v1.5.6'; irm https://clawdcursor.com/install.ps1 | iex
+# Specify version: $env:VERSION='v1.5.7'; irm https://clawdcursor.com/install.ps1 | iex
 #
 # Installs the published npm package globally (npm i -g clawdcursor) -- no git
 # clone, no local build toolchain. Windows needs no native build step.

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Clawd Cursor Installer for macOS / Linux
 # Usage: curl -fsSL https://clawdcursor.com/install.sh | bash
-# Specify version: VERSION=v1.5.6 curl -fsSL https://clawdcursor.com/install.sh | bash
+# Specify version: VERSION=v1.5.7 curl -fsSL https://clawdcursor.com/install.sh | bash
 #
 # Installs the published npm package globally (npm i -g clawdcursor) — no git
 # clone, no local build toolchain. On macOS the package's postinstall builds

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,8 +7,9 @@
 
 How it works: clawdcursor compiles the screen into one fused, confidence-scored UI
 map (accessibility tree + OCR) with stable element ids, and acts on elements by
-name/id — not pixel coordinates. It drops to a screenshot (vision) only as a last
-resort, verifies each consequential action (reports a DEVIATION instead of a hollow
+name/id in the cheap tiers — dropping to screenshot/vision (which DOES use live
+pixel coords off the current frame) only as a last resort for canvas-only or
+custom-drawn UIs. It verifies each consequential action (reports a DEVIATION instead of a hollow
 "success"), and routes every call through a single safety gate (allow / confirm /
 block). This is the fallback/last-mile layer: prefer a native API, a CLI, direct
 file edits, or existing browser automation when those exist; reach for clawdcursor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawdcursor",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawdcursor",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdcursor",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "mcpName": "io.github.AmrDab/clawdcursor",
   "description": "Local MCP server that gives any AI agent safe cross-OS desktop control — the fallback execution layer for when APIs, CLIs, and direct integrations aren't available. Works with any tool-calling model (Claude, GPT, Gemini, Llama) on Windows, macOS, and Linux. Open source (MIT).",
   "homepage": "https://clawdcursor.com",
@@ -57,7 +57,6 @@
     "prebuild": "npm run clean",
     "build": "tsc && node dist/postbuild.js",
     "setup": "node scripts/verify-install.js && npm run build && node -e \"if(process.platform==='darwin'){const{execSync}=require('child_process');try{execSync('chmod +x native/build.sh && native/build.sh',{stdio:'inherit'})}catch(e){console.error('\\n❌ Native build failed. Run manually: cd native && ./build.sh');process.exit(1)}}\" && npm link --force",
-    "postbuild:msg": "handled by postbuild.js",
     "dev": "tsx watch src/surface/cli.ts",
     "start": "node dist/surface/cli.js agent",
     "stop": "node dist/surface/cli.js stop",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/AmrDab/clawdcursor",
     "source": "github"
   },
-  "version": "1.5.6",
+  "version": "1.5.7",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "clawdcursor",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "transport": {
         "type": "stdio"
       },

--- a/skills/clawdcursor/SKILL.md
+++ b/skills/clawdcursor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawdcursor
-version: 1.5.6
+version: 1.5.7
 description: >
   FALLBACK ONLY — do not invoke unless you have already ruled out (1) a
   native API (Gmail API, GitHub API, Slack API …), (2) a CLI (git, gh,
@@ -111,10 +111,9 @@ than the granular surface - so small models (Haiku, Kimi, Ollama) stay focused.
 
 | Tier | Label | Cost | Use when |
 |---|---|---|---|
-| T1 | **structured** | ~free | Default. `accessibility.*`, `window.*`, `browser.read_text`, clipboard. Returns structured text - no image, no vision LLM. |
-| T2 | **ocr** | cheap | A11y tree is empty or sparse. `system({"action":"ocr"})` - OS-level OCR, text out, no LLM vision. |
-| T3 | **screenshot** | medium | OCR isn't enough and you need pixel context. `computer({"action":"screenshot"})` - sends an image into the LLM context. Use sparingly. |
-| T4 | **vision** | expensive | Screen is canvas-only (Paint, Figma, games) or the task requires spatial reasoning that text cannot express. `smart_click`, `smart_read`, `smart_type`. Last resort. |
+| T1 | **structured** | ~free | Default. `accessibility.*`, `window.*`, `browser.read_text`, clipboard. Returns structured text — no image, no vision model. |
+| T2 | **OCR** | cheap | A11y tree is empty or sparse. `system({"action":"ocr"})`, plus `smart_read` / `smart_click` / `smart_type` — all OCR-backed (text out, no image into the model). |
+| T3 | **screenshot / vision** | expensive | Canvas-only apps (Paint, Figma, games) or a task needing spatial reasoning text can't express. `computer({"action":"screenshot"})` puts the current frame into the model's context; you then act on live pixel coords off that frame. "Screenshot" and "vision" are the same tier — the only one that sends pixels to the model. Last resort. |
 
 **Rule: start at T1. Escalate to the next tier only when the current one fails.** Apply this logic when calling compound tools directly; the built-in agent loop (via `task({...})`) follows the same discipline.
 
@@ -263,7 +262,7 @@ clawdcursor agent
 
 ### Autonomous-agent mode
 
-Configure an LLM via `clawdcursor doctor`, then use `submit_task` / `agent_status` / `abort_task` on the granular surface (or `task({...})` on the compact surface) to hand off a plain-English task. The built-in loop perceives the desktop (a11y → OCR → screenshot), acts, and iterates until done or the turn budget is exhausted. See the Modes table above.
+Configure an LLM via `clawdcursor doctor`, then use `submit_task` / `agent_status` / `abort_task` on the granular surface (or `task({...})` on the compact surface) to hand off a plain-English task. The built-in loop compiles the screen (a11y tree + OCR, with screenshot/vision only as last resort), acts on stable element ids, and iterates until done or the turn budget is exhausted. See the Modes table above.
 
 ---
 

--- a/src/__tests__/ocr-engine.test.ts
+++ b/src/__tests__/ocr-engine.test.ts
@@ -62,11 +62,11 @@ vi.mock('child_process', async () => {
     try {
       const result = mockExecFile();
       if (typeof cb === 'function') {
-        (cb as Function)(null, result?.stdout ?? '', result?.stderr ?? '');
+        (cb as (...args: unknown[]) => unknown)(null, result?.stdout ?? '', result?.stderr ?? '');
       }
     } catch (err) {
       if (typeof cb === 'function') {
-        (cb as Function)(err);
+        (cb as (...args: unknown[]) => unknown)(err);
       }
     }
   };

--- a/src/core/agent-loop/agent.ts
+++ b/src/core/agent-loop/agent.ts
@@ -43,7 +43,6 @@ import {
   type LLMToolTurn,
   type LLMUserBlock,
   type ToolUseResult,
-  type LLMAssistantBlock,
 } from '../../llm/client';
 import { buildSystemPrompt, renderSnapshot, renderHistory, wrapUntrustedScreenContent } from './prompt';
 import { LLM_TARGET_WIDTH } from './coord-scale';

--- a/src/core/agent-loop/tools.ts
+++ b/src/core/agent-loop/tools.ts
@@ -19,7 +19,7 @@
  * rank-before-truncate sense layer surface its buttons.
  */
 
-import type { UnifiedTool, UnifiedToolResult, AgentToolContext } from './types';
+import type { UnifiedTool, AgentToolContext } from './types';
 import { buildBatchTool } from './batch-tool';
 import { imageScale, scaleCoord, screenCenter } from './coord-scale';
 import { ensureTargetForeground } from './focus-guard';

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -205,7 +205,6 @@ async function _callText(opts: InternalCallOptions): Promise<string> {
   const {
     baseUrl,
     model,
-    apiKey: _apiKey,
     isAnthropic,
     authHeaders,
     system,

--- a/src/platform/linux.ts
+++ b/src/platform/linux.ts
@@ -1053,6 +1053,7 @@ export class LinuxAdapter implements PlatformAdapter {
     // by DE), so we simply accept it for interface parity.
     void opts?.uwpAppId;
     void opts?.searchTerm;
+    // eslint-disable-next-line no-control-regex -- intentional: reject control chars that could escape shell quoting
     if (/[\r\n\t\x00-\x1f]/.test(name)) {
       throw new Error('launchApp: illegal characters in app name');
     }

--- a/src/platform/macos.ts
+++ b/src/platform/macos.ts
@@ -808,6 +808,7 @@ export class MacOSAdapter implements PlatformAdapter {
     void opts?.uwpAppId;
     // Reject shell-metachar input even though we use execFile (no shell expansion).
     // Keeps parity with Windows' stricter validator and avoids surprising `open`.
+    // eslint-disable-next-line no-control-regex -- intentional: reject control chars that could escape shell quoting
     if (/[\r\n\t\x00-\x1f]/.test(name)) {
       throw new Error('launchApp: illegal characters in app name');
     }

--- a/src/platform/ocr-engine.ts
+++ b/src/platform/ocr-engine.ts
@@ -266,6 +266,7 @@ export class OcrEngine {
 
     // Sanitize control characters that PowerShell's ConvertTo-Json may leave unescaped
     // (e.g. bell \x07 from OCR'd icons). Keep \t, \n, \r which are valid in JSON.
+    // eslint-disable-next-line no-control-regex -- intentional: sanitize control chars that PowerShell's ConvertTo-Json may leave unescaped
     const sanitized = trimmed.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '');
 
     const data = JSON.parse(sanitized);

--- a/src/platform/uri-handler.ts
+++ b/src/platform/uri-handler.ts
@@ -103,7 +103,6 @@ function resolveKnownHandlerForScheme(scheme: string): string | null {
   // 1. Already-running New Outlook (`olk.exe`). Pull its path off the
   //    live process when possible — that's the version actually installed.
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { execSync } = require('node:child_process') as typeof import('node:child_process');
     const out = execSync(
       'wmic process where "name=\'olk.exe\'" get ExecutablePath /value',
@@ -117,7 +116,6 @@ function resolveKnownHandlerForScheme(scheme: string): string | null {
 
   // 2. Glob WindowsApps for the latest Microsoft.OutlookForWindows install.
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { readdirSync, existsSync } = require('node:fs') as typeof import('node:fs');
     const base = 'C:\\Program Files\\WindowsApps';
     if (existsSync(base)) {

--- a/src/platform/windows.ts
+++ b/src/platform/windows.ts
@@ -954,6 +954,7 @@ export class WindowsAdapter implements PlatformAdapter {
   ): Promise<{ pid?: number; title?: string; handle?: number | string }> {
     // Reject control chars / backticks / $() that can escape PowerShell quoting
     // regardless of how we serialize.
+    // eslint-disable-next-line no-control-regex -- intentional: reject control chars that could escape PowerShell quoting
     if (/[\r\n\t\x00-\x1f]/.test(name) || /[`$]/.test(name)) {
       throw new Error('launchApp: illegal characters in app name');
     }
@@ -991,7 +992,7 @@ export class WindowsAdapter implements PlatformAdapter {
       // App ID format is `<PackageFamily>_<Hash>!<AppId>`. Valid characters are
       // alphanumerics, dots, underscores, hyphens, and a single `!`. Reject anything
       // else to keep the shell: path from interpreting metacharacters.
-      if (!/^[A-Za-z0-9_.\-]+![A-Za-z0-9_.\-]+$/.test(id)) {
+      if (!/^[A-Za-z0-9_.-]+![A-Za-z0-9_.-]+$/.test(id)) {
         throw new Error(`launchApp: illegal uwpAppId "${id}"`);
       }
       try {
@@ -1015,9 +1016,11 @@ export class WindowsAdapter implements PlatformAdapter {
     const args = ['-NoProfile', '-Command'];
     const cmdParts: string[] = ['Start-Process'];
     cmdParts.push('-FilePath', this.psQuote(name));
+    // eslint-disable-next-line no-control-regex -- intentional: reject control chars that could escape PowerShell quoting
     if (opts?.url && !/[\r\n\t\x00-\x1f"'`$]/.test(opts.url)) {
       cmdParts.push('-ArgumentList', this.psQuote(opts.url));
     }
+    // eslint-disable-next-line no-control-regex -- intentional: reject control chars that could escape PowerShell quoting
     if (opts?.cwd && !/[\r\n\t\x00-\x1f"'`$]/.test(opts.cwd)) {
       cmdParts.push('-WorkingDirectory', this.psQuote(opts.cwd));
     }

--- a/src/surface/cli.ts
+++ b/src/surface/cli.ts
@@ -447,7 +447,6 @@ async function runAgentMode(opts: AgentModeOpts): Promise<void> {
       try {
         // Lazy require — only attempt when agent existed (scheduler bound).
         if (agent) {
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
           const { stopScheduler } = require('../tools/scheduler');
           stopScheduler();
         }


### PR DESCRIPTION
## What

Final professionalism pass + accuracy reframe (no runtime behavior change). Bumps **1.5.6 → 1.5.7**.

### Accuracy / framing (the big one)
README, the website (`docs/index.html` + `llms.txt`), and `SKILL.md` now describe what clawdcursor actually does — it **compiles the screen into one fused UI map** (a11y tree + OCR, elements with stable `el_NN` ids) and **acts on elements by id**, dropping to the **screenshot/vision tier** (live pixel coords off the current frame) only as a last resort. Replaces the old "reads the a11y tree, screenshots as fallback" line.

Also fixed a cost-tier inaccuracy in `SKILL.md`: "screenshot" and "vision" were two tiers (they're one), and `smart_read`/`smart_click`/`smart_type` were mis-filed under vision when they're OCR-backed (per `cost-class.ts`).

### Repo hygiene
- **ESLint 16 warnings → 0** (dead imports, stale `eslint-disable` directives, useless escapes removed; the intentional control-char sanitisers documented at source).
- Added `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `.editorconfig`, `.gitattributes` (`eol=lf`).
- CI `cross-platform.yml`: `concurrency` group (cancel in-progress PR runs) + 30-min job timeout; dropped the dead `master` push trigger.
- Removed the bogus `postbuild:msg` npm script.
- README stale `v1.5.2` → version-free link to releases.

## Verification
`0` lint errors **and 0 warnings**, `typecheck` + `typecheck:tests` clean, **1113 tests**, build OK, `npm audit --audit-level=high` clean. Version synced across all surfaces (drift guard green, now also covering `marketplace.json` + the single-sourced plugin SKILL.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)