### PR TITLE
fix(security): batch allowConfirm confirm-tier bypass (GHSA-3v3f-5rwv-whc9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Clawd Cursor will be documented in this file.
 
+## [1.5.9] - 2026-07-03 — batch confirm-tier hardening (security)
+
+### Security
+
+- **Close the `batch` `allowConfirm` bypass (GHSA-3v3f-5rwv-whc9, high).** The
+  `batch` MCP tool accepted a caller-controlled `allowConfirm:true` that skipped
+  the confirm-tier `SafetyLayer` halt, letting any bearer-token holder or a
+  compromised agent run confirm-gated actions (e.g. `open_uri file:` launching an
+  arbitrary OS handler) that a direct `tools/call` would stop. `allowConfirm` is
+  now honored only when the operator started the daemon with
+  `CLAWD_BATCH_ALLOW_CONFIRM=1`; a caller-supplied flag alone can no longer
+  satisfy a confirm step. Block-tier remains unbypassable, and the agent-loop
+  batch was never affected (it already halts on any non-allow verdict). v1.5.8
+  and earlier are affected; there is no npm release of 1.5.8 (it went straight
+  to 1.5.9).
+
 ## [1.5.8] - 2026-07-02 — the agent path clicks straight
 
 The autonomous agent path (`clawdcursor agent` + granular `click`/`smart_click`)

--- a/schema.snapshot.json
+++ b/schema.snapshot.json
@@ -210,7 +210,7 @@
     },
     {
       "name": "batch",
-      "description": "Run an ORDERED LIST of tool calls in one shot (collapses many round-trips into one). Each step is { name, arguments, expect? }. `name`+`arguments` is a normal tool call (compound like {\"name\":\"computer\",\"arguments\":{\"action\":\"type\",\"text\":\"hi\"}} or a granular tool). Optional `expect` is a precondition checked by RE-PERCEIVING before the step runs: {\"window\":\"notepad\"} (foreground window must match) or {\"element\":\"Send\"} (a11y element must be present). The batch HALTS on the first failed precondition, safety stop, or step error and returns a per-step trace so you re-plan from real state. Every step goes through the same safety gate as a direct call. Use `expect` to guarantee you act on the right window/element instead of guessing. Set dryRun:true to pre-scan safety tiers without executing; allowConfirm:true to let confirm-tier steps proceed.",
+      "description": "Run an ORDERED LIST of tool calls in one shot (collapses many round-trips into one). Each step is { name, arguments, expect? }. `name`+`arguments` is a normal tool call (compound like {\"name\":\"computer\",\"arguments\":{\"action\":\"type\",\"text\":\"hi\"}} or a granular tool). Optional `expect` is a precondition checked by RE-PERCEIVING before the step runs: {\"window\":\"notepad\"} (foreground window must match) or {\"element\":\"Send\"} (a11y element must be present). The batch HALTS on the first failed precondition, safety stop, or step error and returns a per-step trace so you re-plan from real state. Every step goes through the same safety gate as a direct call. Use `expect` to guarantee you act on the right window/element instead of guessing. Set dryRun:true to pre-scan safety tiers without executing. A confirm-tier step still HALTS the batch by default; allowConfirm:true only proceeds if the operator started the daemon with CLAWD_BATCH_ALLOW_CONFIRM=1 (otherwise it is ignored — confirm-tier stays gated).",
       "category": "orchestration",
       "parameters": {
         "type": "object",
@@ -241,7 +241,7 @@
           },
           "allowConfirm": {
             "type": "boolean",
-            "description": "Allow confirm-tier steps to run (default false → halt at them)."
+            "description": "Request that confirm-tier steps proceed. Only effective if the operator enabled CLAWD_BATCH_ALLOW_CONFIRM=1 on the daemon; otherwise ignored and the batch halts at the confirm step. Never bypasses block-tier."
           },
           "dryRun": {
             "type": "boolean",

--- a/src/__tests__/batch.test.ts
+++ b/src/__tests__/batch.test.ts
@@ -4,7 +4,7 @@
  * isolation: ordered execution, precondition guards (re-perceive), safety
  * halting, error halting, the trace, dry-run, and the step cap.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Mock the two collaborators the executor reuses ──────────────────────────
 const tools: Record<string, any> = {};
@@ -113,20 +113,50 @@ describe('executeBatch — guards (re-perceive precondition)', () => {
 });
 
 describe('executeBatch — safety', () => {
-  it('halts at a confirm-tier step unless allowConfirm is set', async () => {
+  const ENV_KEY = 'CLAWD_BATCH_ALLOW_CONFIRM';
+  let prevEnv: string | undefined;
+  beforeEach(() => { prevEnv = process.env[ENV_KEY]; delete process.env[ENV_KEY]; });
+  afterEach(() => { if (prevEnv === undefined) delete process.env[ENV_KEY]; else process.env[ENV_KEY] = prevEnv; });
+
+  it('halts at a confirm-tier step by default (no allowConfirm)', async () => {
     tools.close_window = okTool('close_window');
     safetyFor = (name) => name === 'close_window' ? { text: 'close_window: safety confirm - destructive', isError: true } : null;
 
     const blocked = await executeBatch([{ name: 'close_window' }], ctx);
     expect(blocked.steps[0].status).toBe('needs_confirm');
     expect(tools.close_window.handler).not.toHaveBeenCalled();
+  });
 
+  // GHSA-3v3f-5rwv-whc9: a caller-supplied allowConfirm must NOT bypass the
+  // confirm tier on its own — only the operator env flag unlocks it.
+  it('SECURITY: caller allowConfirm alone does NOT bypass confirm tier', async () => {
+    tools.close_window = okTool('close_window');
+    safetyFor = (name) => name === 'close_window' ? { text: 'close_window: safety confirm - destructive', isError: true } : null;
+    // env NOT set (cleared in beforeEach) → the exploit path
+    const attempt = await executeBatch([{ name: 'close_window' }], ctx, { allowConfirm: true });
+    expect(attempt.allDone).toBe(false);
+    expect(attempt.steps[0].status).toBe('needs_confirm');
+    expect(tools.close_window.handler).not.toHaveBeenCalled();
+  });
+
+  it('proceeds only when operator env flag AND caller allowConfirm are both set', async () => {
+    tools.close_window = okTool('close_window');
+    safetyFor = (name) => name === 'close_window' ? { text: 'close_window: safety confirm - destructive', isError: true } : null;
+
+    process.env[ENV_KEY] = '1';
+    // operator enabled, but caller did NOT ask → still halts
+    const noAsk = await executeBatch([{ name: 'close_window' }], ctx);
+    expect(noAsk.steps[0].status).toBe('needs_confirm');
+    expect(tools.close_window.handler).not.toHaveBeenCalled();
+
+    // both present → proceeds
     const allowed = await executeBatch([{ name: 'close_window' }], ctx, { allowConfirm: true });
     expect(allowed.allDone).toBe(true);
     expect(tools.close_window.handler).toHaveBeenCalled();
   });
 
-  it('always halts at a hard block, even with allowConfirm', async () => {
+  it('always halts at a hard block, even with the operator flag + allowConfirm', async () => {
+    process.env[ENV_KEY] = '1';
     tools.dangerous = okTool('dangerous');
     safetyFor = () => ({ text: 'dangerous: safety block - not allowed', isError: true });
     const r = await executeBatch([{ name: 'dangerous' }], ctx, { allowConfirm: true });

--- a/src/tools/batch.ts
+++ b/src/tools/batch.ts
@@ -31,6 +31,25 @@ function resolveAnyTool(name: string): ToolDefinition | undefined {
   return getTool(name) ?? getCompactTools().find(t => t.name === name);
 }
 
+/**
+ * Whether the OPERATOR has opted into letting a batch auto-satisfy confirm-tier
+ * steps. Security boundary (GHSA-3v3f-5rwv-whc9): the per-call `allowConfirm`
+ * JSON field is caller-controlled — any bearer-token holder or a compromised/
+ * malicious agent could set it and execute confirm-gated actions (e.g. `open_uri
+ * file:` launching an arbitrary handler) that a direct tools/call would halt on.
+ * The confirm tier exists precisely to require a human, and the caller IS the
+ * (untrusted) agent, so caller-supplied consent is not consent. We therefore
+ * only honor `allowConfirm` when the human running the daemon has enabled it
+ * out-of-band via CLAWD_BATCH_ALLOW_CONFIRM=1 (or =true). Default: OFF — a batch
+ * halts at a confirm step exactly like a direct call, and reports how to enable
+ * it deliberately. This does not weaken the block tier (never bypassable) and
+ * does not touch benign/allow-tier steps.
+ */
+export function batchAutoConfirmEnabled(): boolean {
+  const v = (process.env.CLAWD_BATCH_ALLOW_CONFIRM || '').trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
 /** A lightweight, declarative precondition checked (by re-perceiving) before a step runs. */
 export interface BatchGuard {
   /** An a11y element with this name must be present in the current UI. */
@@ -153,9 +172,17 @@ export async function executeBatch(
     const safetyErr = evaluateToolCall(tool, args, { uiMaps: ctx.uiMaps });
     if (safetyErr) {
       const isConfirm = (safetyErr.text || '').includes('safety confirm');
-      if (!(isConfirm && opts.allowConfirm)) {
+      // `allowConfirm` is only effective when the OPERATOR enabled it out-of-band
+      // (CLAWD_BATCH_ALLOW_CONFIRM=1). A caller-supplied allowConfirm alone can
+      // NOT satisfy a confirm-tier step — see GHSA-3v3f-5rwv-whc9. Block tier is
+      // never bypassable.
+      const mayAutoConfirm = isConfirm && opts.allowConfirm && batchAutoConfirmEnabled();
+      if (!mayAutoConfirm) {
         outcomes.push({ i, label, status: isConfirm ? 'needs_confirm' : 'blocked', text: safetyErr.text });
-        return halt(i, isConfirm ? `step ${i} needs confirmation (re-submit with allowConfirm:true if intended)` : `step ${i} blocked by safety`);
+        const confirmHint = opts.allowConfirm
+          ? `step ${i} needs confirmation — allowConfirm is ignored unless the operator sets CLAWD_BATCH_ALLOW_CONFIRM=1 on the daemon`
+          : `step ${i} needs confirmation (a confirm-tier step cannot run in a batch unless the operator enables CLAWD_BATCH_ALLOW_CONFIRM=1 AND you pass allowConfirm:true)`;
+        return halt(i, isConfirm ? confirmHint : `step ${i} blocked by safety`);
       }
     }
 
@@ -211,7 +238,9 @@ export function getBatchTools(): ToolDefinition[] {
         'failed precondition, safety stop, or step error and returns a per-step trace so you re-plan from real ' +
         'state. Every step goes through the same safety gate as a direct call. Use `expect` to guarantee you ' +
         'act on the right window/element instead of guessing. Set dryRun:true to pre-scan safety tiers without ' +
-        'executing; allowConfirm:true to let confirm-tier steps proceed.',
+        'executing. A confirm-tier step still HALTS the batch by default; ' +
+        'allowConfirm:true only proceeds if the operator started the daemon with ' +
+        'CLAWD_BATCH_ALLOW_CONFIRM=1 (otherwise it is ignored — confirm-tier stays gated).',
       parameters: {
         steps: {
           type: 'array',
@@ -227,7 +256,7 @@ export function getBatchTools(): ToolDefinition[] {
             required: ['name'],
           },
         },
-        allowConfirm: { type: 'boolean', description: 'Allow confirm-tier steps to run (default false → halt at them).', required: false },
+        allowConfirm: { type: 'boolean', description: 'Request that confirm-tier steps proceed. Only effective if the operator enabled CLAWD_BATCH_ALLOW_CONFIRM=1 on the daemon; otherwise ignored and the batch halts at the confirm step. Never bypasses block-tier.', required: false },
         dryRun: { type: 'boolean', description: 'Only report each step\'s safety tier; do not execute.', required: false },
         maxSteps: { type: 'number', description: `Hard cap on executed steps (default ${DEFAULT_MAX_STEPS}).`, required: false },
       },
@@ -262,7 +291,14 @@ export function getBatchTools(): ToolDefinition[] {
             text:
               `batch (dry run): ${steps.length} steps.\n` +
               scan.map(s => `  ${s.i}. [${s.gate}] ${s.label}`).join('\n') +
-              (willStop ? `\nNote: without allowConfirm, the batch would halt at step ${willStop.i} ([${willStop.gate}]).` : '\nAll steps would be allowed.'),
+              (willStop
+                ? `\nNote: the batch would halt at step ${willStop.i} ([${willStop.gate}]).` +
+                  (willStop.gate === 'confirm'
+                    ? (batchAutoConfirmEnabled()
+                        ? ' Pass allowConfirm:true to proceed (operator has enabled it).'
+                        : ' Confirm-tier steps cannot run in a batch on this daemon (operator has not set CLAWD_BATCH_ALLOW_CONFIRM=1).')
+                    : '')
+                : '\nAll steps would be allowed.'),
           };
         }
 


### PR DESCRIPTION
Fixes **GHSA-3v3f-5rwv-whc9** (high) — the `batch` `allowConfirm` confirm-tier bypass.

**Problem:** `batch` honored a caller-controlled `allowConfirm:true` that skipped the confirm-tier `SafetyLayer` halt. Any bearer-token holder / compromised agent could run confirm-gated actions (e.g. `open_uri file:` → arbitrary OS handler) that a direct `tools/call` refuses. Privilege escalation over the direct path.

**Fix:** `allowConfirm` is effective only when the operator set `CLAWD_BATCH_ALLOW_CONFIRM=1` on the daemon (out-of-band human control). Caller flag alone can't satisfy a confirm step; block-tier stays unbypassable. The agent-loop batch was never affected.

- Server-side gate `batchAutoConfirmEnabled()` at the batch safety choke point
- Tool description / param doc / dry-run note corrected
- Security regression test: the exploit path asserts the handler is NOT called

Ships as v1.5.9. Full suite green (87 files), including the new SECURITY test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
